### PR TITLE
kula: update repo name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Getting Started
 
 1. Clone the git repository:
 
-    $ git clone https://github.com/gratian/nile.git
+    $ git clone https://github.com/ni/nile.git
 
 2. Check out the appropriate branch (default scarthgap based branch is OK for now):
 


### PR DESCRIPTION
Update the repository URL in the readme to point to the new NI repository instead of Gratian's version that it was forked from.