### PR TITLE
qemu: Add bbappend files to force master branch

### DIFF
--- a/meta-nile/recipes-devtools/qemu/qemu-xilinx-native_8.2.7.bbappend
+++ b/meta-nile/recipes-devtools/qemu/qemu-xilinx-native_8.2.7.bbappend
@@ -1,0 +1,3 @@
+
+BRANCH = "master"
+SRCREV = "e04ff21b1a160e2230ae96542464ac9467ecb62f"

--- a/meta-nile/recipes-devtools/qemu/qemu-xilinx-system-native_8.2.7.bbappend
+++ b/meta-nile/recipes-devtools/qemu/qemu-xilinx-system-native_8.2.7.bbappend
@@ -1,0 +1,3 @@
+
+BRANCH = "master"
+SRCREV = "e04ff21b1a160e2230ae96542464ac9467ecb62f"

--- a/meta-nile/recipes-devtools/qemu/qemu-xilinx_8.2.7.bbappend
+++ b/meta-nile/recipes-devtools/qemu/qemu-xilinx_8.2.7.bbappend
@@ -1,0 +1,3 @@
+
+BRANCH = "master"
+SRCREV = "e04ff21b1a160e2230ae96542464ac9467ecb62f"


### PR DESCRIPTION
Added bbappend files that force the meta-xilinx submodule to pull from the xilinx/qemu master branch. This is necessary because that branch is the only one that contains the fix that allows the use of the qemu u-boot and u-boot-sam460ex repositories.

### Testing
Built the nile-image-dev target locally and used runqemu to start a qemu session.