### PR TITLE
Fix workflow condition to set variables for a PR pipeline run

### DIFF
--- a/.github/workflows/trigger_azdo_pipeline.yml
+++ b/.github/workflows/trigger_azdo_pipeline.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ni-dev
     steps:
-      - name: Set variables for pull_request
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Set variables for PR run
+        if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           echo "BUILD_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "REPO_URL=${{ github.server_url }}/${{ github.event.pull_request.head.repo.full_name }}.git" >> $GITHUB_ENV


### PR DESCRIPTION
The trigger condition changed from pull_request to pull_request_target, but the step to set variables for the run was not updated. Fixed the condition for the workflow to set the appropriate variables when a PR is the trigger.

`github.event.pull_request` variables are still valid, there's no need to update those.