### PR TITLE
iba: Add kula-vmk180 machine variant

### DIFF
--- a/kas/machines/kula-vmk180.yml
+++ b/kas/machines/kula-vmk180.yml
@@ -1,0 +1,35 @@
+header:
+  version: 19
+  includes:
+    - kas/includes/meta-xilinx.yml
+    - kas/includes/meta-virtualization.yml
+    - kas/includes/meta-rauc.yml
+    - kas/includes/xilinx-device-common.yml
+
+machine: kula-vmk180
+
+repos:
+  meta-iba:
+    path: "meta-iba"
+    layers:
+      .:
+
+  meta-xilinx:
+    layers:
+      meta-xilinx-bsp:
+      meta-microblaze:
+      meta-xilinx-core:
+      meta-xilinx-standalone:
+      meta-xilinx-standalone-sdt:
+
+  meta-xilinx-tools:
+    layers:
+      .:
+
+  meta-amd-adaptive-socs:
+    layers:
+      meta-amd-adaptive-socs-core:
+
+  meta-openamp:
+    layers:
+      .:

--- a/kas/targets/nile-image-dev_kula-vmk180.lock.yml
+++ b/kas/targets/nile-image-dev_kula-vmk180.lock.yml
@@ -1,0 +1,22 @@
+header:
+  version: 14
+overrides:
+  repos:
+    bitbake:
+      commit: 8dcf084522b9c66a6639b5f117f554fde9b6b45a
+    meta-amd-adaptive-socs:
+      commit: 6b7eef28e7277e43bc01d8e0f1a0445923fb74a3
+    meta-arm:
+      commit: a81c19915b5b9e71ed394032e9a50fd06919e1cd
+    meta-openamp:
+      commit: e44e4a3b4abe9cc5fdfe75c43181ba82750f6865
+    meta-openembedded:
+      commit: 2759d8870ea387b76c902070bed8a6649ff47b56
+    meta-virtualization:
+      commit: f92518e20530edfebca45e4170e11460949a5303
+    meta-xilinx:
+      commit: 936845b97ab1ff035108f219f4e7cfef5401eb02
+    meta-xilinx-tools:
+      commit: fb6908f6a63c5c79cb1c096f54d8ef5605eb7b74
+    openembedded-core:
+      commit: 6988157ad983978ffd6b12bcefedd4deaffdbbd1

--- a/kas/targets/nile-image-dev_kula-vmk180.yml
+++ b/kas/targets/nile-image-dev_kula-vmk180.yml
@@ -1,0 +1,24 @@
+header:
+  version: 19
+  includes:
+    - kas/includes/base-config.yml
+    - kas/machines/kula-vmk180.yml
+
+target:
+  - nile-image-dev
+
+artifacts:
+  "Image.bin": "tmp/deploy/images/kula-vmk180/Image-kula-vmk180.bin"
+  "boot.bin": "tmp/deploy/images/kula-vmk180/boot.bin"
+  "boot.scr": "tmp/deploy/images/kula-vmk180/boot.scr"
+  "nile-image-dev-kula-vmk180.rootfs.cpio.gz.u-boot": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.cpio.gz.u-boot"
+  "nile-image-dev-kula-vmk180.rootfs.tar.gz": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.tar.gz"
+  "nile-image-dev-kula-vmk180.rootfs.qemuboot.conf": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.qemuboot.conf"
+  "qemu/nile-image-dev-kula-vmk180.rootfs.wic.qemu-sd": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.wic.qemu-sd"
+  "qemu/plm-kula-vmk180.elf": "tmp/deploy/images/kula-vmk180/plm-kula-vmk180.elf"
+  "qemu/cortexa72-linux.dtb": "tmp/deploy/images/kula-vmk180/devicetree/cortexa72-linux.dtb"
+  "qemu/BOOT-kula-vmk180_bh.bin": "tmp/deploy/images/kula-vmk180/BOOT-kula-vmk180_bh.bin"
+  "qemu/BOOT-kula-vmk180.bin": "tmp/deploy/images/kula-vmk180/BOOT-kula-vmk180.bin"
+  "qemu/CDO": "tmp/deploy/images/kula-vmk180/CDO"
+  "qemu/qemu-hw-devicetrees": "tmp/deploy/images/kula-vmk180/qemu-hw-devicetrees"
+  "qemu/bin": "tmp/work/x86_64-linux/qemu-helper-native/1.0/recipe-sysroot-native/usr/bin"

--- a/meta-nile/conf/dts/kula-vmk180/cortexa72-linux.dts
+++ b/meta-nile/conf/dts/kula-vmk180/cortexa72-linux.dts
@@ -1,0 +1,1737 @@
+/dts-v1/;
+
+/ {
+        compatible = "xlnx,versal-vmk180-revA", "xlnx,versal";
+        #address-cells = <0x2>;
+        #size-cells = <0x2>;
+        model = "Xilinx Versal vmk180 Eval board revA";
+        board = "vmk180";
+        device_id = "xcvm1802";
+        slrcount = <0x1>;
+        family = "Versal";
+
+        options {
+
+                u-boot {
+                        compatible = "u-boot,config";
+                        bootscr-address = <0x0 0x20000000>;
+                };
+        };
+
+        cpus_a72: cpus {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                #ranges-address-cells = <0x2>;
+                #ranges-size-cells = <0x2>;
+                phandle = <0x9d>;
+
+                psv_cortexa72_0: cpu@0 {
+                        compatible = "arm,cortex-a72", "arm,armv8";
+                        device_type = "cpu";
+                        enable-method = "psci";
+                        operating-points-v2 = <&cpu_opp_table>;
+                        reg = <0x0>;
+                        cpu-idle-states = <&CPU_SLEEP_0>;
+                        power-domains = <&versal_firmware 0x18110003>;
+                        clocks = <&versal_clk 0x4d>;
+                        xlnx,timestamp-clk-freq = <0x5f5dd19>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        stamp-frequency = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_cortexa72";
+                        xlnx,cpu-clk-freq-hz = <0x5372172a>;
+                        cpu-frequency = <0x5372172a>;
+                        bus-handle = <0x1>;
+                        phandle = <0x9e>;
+                };
+
+                psv_cortexa72_1: cpu@1 {
+                        compatible = "arm,cortex-a72", "arm,armv8";
+                        device_type = "cpu";
+                        enable-method = "psci";
+                        operating-points-v2 = <&cpu_opp_table>;
+                        reg = <0x1>;
+                        cpu-idle-states = <&CPU_SLEEP_0>;
+                        power-domains = <&versal_firmware 0x18110004>;
+                        xlnx,timestamp-clk-freq = <0x5f5dd19>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        stamp-frequency = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_cortexa72";
+                        xlnx,cpu-clk-freq-hz = <0x5372172a>;
+                        cpu-frequency = <0x5372172a>;
+                        bus-handle = <0x1>;
+                        phandle = <0x9f>;
+                };
+
+                idle-states {
+                        entry-method = "psci";
+
+                        CPU_SLEEP_0: cpu-sleep-0 {
+                                compatible = "arm,idle-state";
+                                arm,psci-suspend-param = <0x40000000>;
+                                local-timer-stop;
+                                entry-latency-us = <0x12c>;
+                                exit-latency-us = <0x258>;
+                                min-residency-us = <0x2710>;
+                                phandle = <0x74>;
+                        };
+                };
+        };
+
+        cpu_opp_table: opp-table-cpu {
+                compatible = "operating-points-v2";
+                opp-shared;
+                phandle = <0x73>;
+
+                opp-1400000000 {
+                        opp-hz = <0x0 0x53724e00>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-700000000 {
+                        opp-hz = <0x0 0x29b92700>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-466666666 {
+                        opp-hz = <0x0 0x1bd0c4aa>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-350000000 {
+                        opp-hz = <0x0 0x14dc9380>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+        };
+
+        dcc: dcc {
+                compatible = "arm,dcc";
+                status = "disabled";
+                bootph-all;
+                phandle = <0xa8>;
+        };
+
+        fpga: fpga-region {
+                compatible = "fpga-region";
+                fpga-mgr = <&versal_fpga>;
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0xa9>;
+        };
+
+        psci: psci {
+                compatible = "arm,psci-0.2";
+                method = "smc";
+                phandle = <0xaa>;
+        };
+
+        pmu {
+                compatible = "arm,armv8-pmuv3";
+                interrupt-parent = <&gic>;
+                interrupts = <0x1 0x7 0x304>;
+        };
+
+        timer: timer {
+                compatible = "arm,armv8-timer";
+                interrupt-parent = <&gic>;
+                interrupts = <0x1 0xd 0x4 0x1 0xe 0x4 0x1 0xb 0x4 0x1 0xa 0x4>;
+                phandle = <0xab>;
+        };
+
+        versal_fpga: versal-fpga {
+                compatible = "xlnx,versal-fpga";
+                phandle = <0x8f>;
+        };
+
+        sensor0: versal-thermal-sensor {
+                compatible = "xlnx,versal-thermal";
+                #thermal-sensor-cells = <0x0>;
+                io-channels = <0x37>;
+                io-channel-names = "sysmon-temp-channel";
+                phandle = <0x91>;
+        };
+
+        thermal-zones {
+
+                versal_thermal: versal-thermal {
+                        polling-delay-passive = <0xfa>;
+                        polling-delay = <0x3e8>;
+                        thermal-sensors = <0x91>;
+                        phandle = <0xac>;
+
+                        trips {
+
+                                temp_alert: temp-alert {
+                                        temperature = <0x11170>;
+                                        hysteresis = <0x0>;
+                                        type = "passive";
+                                        phandle = <0xad>;
+                                };
+
+                                ot_crit: ot-crit {
+                                        temperature = <0x1e848>;
+                                        hysteresis = <0x0>;
+                                        type = "critical";
+                                        phandle = <0xae>;
+                                };
+                        };
+                };
+        };
+
+        amba: axi {
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&gic>;
+                bootph-all;
+                phandle = <0x1>;
+
+                can0: can@ff060000 {
+                        compatible = "xlnx,canfd-2.0";
+                        status = "disabled";
+                        reg = <0x0 0xff060000 0x0 0x6000>;
+                        interrupts = <0x0 0x14 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "can_clk", "s_axi_aclk";
+                        rx-fifo-depth = <0x40>;
+                        tx-mailbox-count = <0x20>;
+                        clocks = <&can0_clk>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401f>;
+                        phandle = <0xaf>;
+                };
+
+                can1: can@ff070000 {
+                        compatible = "xlnx,canfd-2.0";
+                        status = "disabled";
+                        reg = <0x0 0xff070000 0x0 0x6000>;
+                        interrupts = <0x0 0x15 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "can_clk", "s_axi_aclk";
+                        rx-fifo-depth = <0x40>;
+                        tx-mailbox-count = <0x20>;
+                        clocks = <&can1_clk>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224020>;
+                        phandle = <0xb0>;
+                };
+
+                cci: cci@fd000000 {
+                        compatible = "arm,cci-500";
+                        status = "okay";
+                        reg = <0x0 0xfd000000 0x0 0x10000>;
+                        ranges = <0x0 0x0 0xfd000000 0xa0000>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x1>;
+                        xlnx,ip-name = "psv_fpd_maincci";
+                        phandle = <0x42>;
+
+                        cci_pmu: pmu@10000 {
+                                compatible = "arm,cci-500-pmu,r0";
+                                reg = <0x10000 0x90000>;
+                                interrupt-parent = <&gic>;
+                                interrupts = <0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4>;
+                                phandle = <0xb1>;
+                        };
+                };
+
+                lpd_dma_chan0: dma-controller@ffa80000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffa80000 0x0 0x1000>;
+                        interrupts = <0x0 0x3c 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224035>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x61>;
+                };
+
+                lpd_dma_chan1: dma-controller@ffa90000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffa90000 0x0 0x1000>;
+                        interrupts = <0x0 0x3d 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224036>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x62>;
+                };
+
+                lpd_dma_chan2: dma-controller@ffaa0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffaa0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3e 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224037>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x63>;
+                };
+
+                lpd_dma_chan3: dma-controller@ffab0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffab0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3f 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224038>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x64>;
+                };
+
+                lpd_dma_chan4: dma-controller@ffac0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffac0000 0x0 0x1000>;
+                        interrupts = <0x0 0x40 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224039>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x65>;
+                };
+
+                lpd_dma_chan5: dma-controller@ffad0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffad0000 0x0 0x1000>;
+                        interrupts = <0x0 0x41 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403a>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x66>;
+                };
+
+                lpd_dma_chan6: dma-controller@ffae0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffae0000 0x0 0x1000>;
+                        interrupts = <0x0 0x42 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403b>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x67>;
+                };
+
+                lpd_dma_chan7: dma-controller@ffaf0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffaf0000 0x0 0x1000>;
+                        interrupts = <0x0 0x43 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403c>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        phandle = <0x68>;
+                };
+
+                gem0: ethernet@ff0c0000 {
+                        compatible = "xlnx,versal-gem", "cdns,gem";
+                        status = "okay";
+                        reg = <0x0 0xff0c0000 0x0 0x1000>;
+                        interrupts = <0x0 0x38 0x4 0x0 0x38 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x52>,
+                         <&versal_clk 0x58>,
+                         <&versal_clk 0x31>,
+                         <&versal_clk 0x30>,
+                         <&versal_clk 0x2b>;
+                        power-domains = <&versal_firmware 0x18224019>;
+                        xlnx,has-mdio = <0x1>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,gem-board-interface = "custom";
+                        phy-mode = "rgmii-id";
+                        xlnx,enet-slcr-1000mbps-div0 = <0x2>;
+                        xlnx,enet-slcr-10mbps-div0 = <0x64>;
+                        xlnx,enet-tsu-clk-freq-hz = <0xee6a8ba>;
+                        xlnx,ip-name = "psv_ethernet";
+                        xlnx,eth-mode = <0x1>;
+                        xlnx,enet-clk-freq-hz = <0x773545d>;
+                        xlnx,enet-slcr-100mbps-div0 = <0xa>;
+                        local-mac-address = [00 0A 23 00 00 00];
+                        phy-handle = <0x94>;
+                        phandle = <0x54>;
+
+                        mdio: mdio {
+                                #address-cells = <0x1>;
+                                #size-cells = <0x0>;
+                                phandle = <0xb2>;
+
+                                phy1: ethernet-phy@1 {
+                                        #phy-cells = <0x1>;
+                                        compatible = "ethernet-phy-id2000.a231";
+                                        reg = <0x1>;
+                                        ti,rx-internal-delay = <0xb>;
+                                        ti,tx-internal-delay = <0xa>;
+                                        ti,fifo-depth = <0x1>;
+                                        ti,dp83867-rxctrl-strap-quirk;
+                                        reset-assert-us = <0x64>;
+                                        reset-deassert-us = <0x118>;
+                                        reset-gpios = <&gpio1 0x30 0x1>;
+                                        phandle = <0x94>;
+                                };
+
+                                phy2: ethernet-phy@2 {
+                                        #phy-cells = <0x1>;
+                                        compatible = "ethernet-phy-id2000.a231";
+                                        reg = <0x2>;
+                                        ti,rx-internal-delay = <0xb>;
+                                        ti,tx-internal-delay = <0xa>;
+                                        ti,fifo-depth = <0x1>;
+                                        ti,dp83867-rxctrl-strap-quirk;
+                                        reset-assert-us = <0x64>;
+                                        reset-deassert-us = <0x118>;
+                                        reset-gpios = <&gpio1 0x31 0x1>;
+                                        phandle = <0x96>;
+                                };
+                        };
+                };
+
+                gem1: ethernet@ff0d0000 {
+                        compatible = "xlnx,versal-gem", "cdns,gem";
+                        status = "disabled";
+                        reg = <0x0 0xff0d0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3a 0x4 0x0 0x3a 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x52>,
+                         <&versal_clk 0x59>,
+                         <&versal_clk 0x33>,
+                         <&versal_clk 0x32>,
+                         <&versal_clk 0x2b>;
+                        power-domains = <&versal_firmware 0x1822401a>;
+                        phy-handle = <0x96>;
+                        phy-mode = "rgmii-id";
+                        phandle = <0xb3>;
+                };
+
+                gpio0: gpio@ff0b0000 {
+                        compatible = "xlnx,versal-gpio-1.0";
+                        status = "okay";
+                        reg = <0x0 0xff0b0000 0x0 0x1000>;
+                        interrupts = <0x0 0xd 0x4>;
+                        interrupt-parent = <&gic>;
+                        #gpio-cells = <0x2>;
+                        gpio-controller;
+                        #interrupt-cells = <0x2>;
+                        interrupt-controller;
+                        clocks = <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224023>;
+                        xlnx,ip-name = "psv_gpio";
+                        emio-gpio-width = [00];
+                        phandle = <0x53>;
+                };
+
+                gpio1: gpio@f1020000 {
+                        compatible = "xlnx,pmc-gpio-1.0";
+                        status = "disabled";
+                        reg = <0x0 0xf1020000 0x0 0x1000>;
+                        interrupts = <0x0 0x7a 0x4>;
+                        interrupt-parent = <&gic>;
+                        #gpio-cells = <0x2>;
+                        gpio-controller;
+                        #interrupt-cells = <0x2>;
+                        interrupt-controller;
+                        clocks = <&versal_clk 0x3d>;
+                        power-domains = <&versal_firmware 0x1822402c>;
+                        phandle = <0x95>;
+                };
+
+                i2c0: i2c@ff020000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "disabled";
+                        reg = <0x0 0xff020000 0x0 0x1000>;
+                        interrupts = <0x0 0xe 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x62>;
+                        power-domains = <&versal_firmware 0x1822401d>;
+                        phandle = <0xb4>;
+                };
+
+                i2c1: i2c@ff030000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "okay";
+                        reg = <0x0 0xff030000 0x0 0x1000>;
+                        interrupts = <0x0 0xf 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x63>;
+                        power-domains = <&versal_firmware 0x1822401e>;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,i2c-clk-freq-hz = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_i2c";
+                        xlnx,iic-board-interface = "custom";
+                        phandle = <0x50>;
+                };
+
+                i2c2: i2c@f1000000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "okay";
+                        reg = <0x0 0xf1000000 0x0 0x1000>;
+                        interrupts = <0x0 0x7b 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x3e>;
+                        power-domains = <&versal_firmware 0x1822402d>;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,i2c-clk-freq-hz = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_pmc_i2c";
+                        phandle = <0x28>;
+                };
+
+                mc1: memory-controller@f62c0000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf62c0000 0x0 0x2000 0x0 0xf6210000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&gic>;
+                        phandle = <0xb6>;
+                };
+
+                mc2: memory-controller@f6430000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf6430000 0x0 0x2000 0x0 0xf6380000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&gic>;
+                        phandle = <0xb7>;
+                };
+
+                mc3: memory-controller@f65a0000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf65a0000 0x0 0x2000 0x0 0xf64f0000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&gic>;
+                        phandle = <0xb8>;
+                };
+
+                ocm: memory-controller@ff960000 {
+                        compatible = "xlnx,zynqmp-ocmc-1.0";
+                        reg = <0x0 0xff960000 0x0 0x1000>;
+                        interrupts = <0x0 0xa 0x4>;
+                        interrupt-parent = <&gic>;
+                        phandle = <0xb9>;
+                };
+
+                rtc: rtc@f12a0000 {
+                        compatible = "xlnx,zynqmp-rtc";
+                        status = "okay";
+                        reg = <0x0 0xf12a0000 0x0 0x100>;
+                        interrupt-names = "alarm", "sec";
+                        interrupts = <0x0 0x8e 0x4 0x0 0x8f 0x4>;
+                        interrupt-parent = <&gic>;
+                        calibration = <0x7fff>;
+                        power-domains = <&versal_firmware 0x18224034>;
+                        xlnx,ip-name = "psv_pmc_rtc";
+                        phandle = <0x38>;
+                };
+
+                sdhci0: mmc@f1040000 {
+                        compatible = "xlnx,versal-8.9a", "arasan,sdhci-8.9a";
+                        status = "disabled";
+                        reg = <0x0 0xf1040000 0x0 0x10000>;
+                        interrupts = <0x0 0x7e 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_xin", "clk_ahb", "gate";
+                        #clock-cells = <0x1>;
+                        clock-output-names = "clk_out_sd0", "clk_in_sd0";
+                        clocks = <&versal_clk 0x3b>,
+                         <&versal_clk 0x52>,
+                         <&versal_clk 0x4a>;
+                        power-domains = <&versal_firmware 0x1822402e>;
+                        phandle = <0xba>;
+                };
+
+                sdhci1: mmc@f1050000 {
+                        compatible = "xlnx,versal-8.9a", "arasan,sdhci-8.9a";
+                        status = "okay";
+                        reg = <0x0 0xf1050000 0x0 0x10000>;
+                        interrupts = <0x0 0x80 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "clk_xin", "clk_ahb", "gate";
+                        #clock-cells = <0x1>;
+                        clock-output-names = "clk_out_sd1", "clk_in_sd1";
+                        clocks = <&versal_clk 0x3c>,
+                         <&versal_clk 0x52>,
+                         <&versal_clk 0x4a>;
+                        power-domains = <&versal_firmware 0x1822402f>;
+                        xlnx,sd-board-interface = "custom";
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,clk-50-ddr-otap-dly = <0x0>;
+                        xlnx,clk-50-sdr-itap-dly = <0x2c>;
+                        xlnx,has-emio = <0x0>;
+                        clock-frequency = <0xbebba31>;
+                        xlnx,clk-100-sdr-otap-dly = <0x0>;
+                        xlnx,mio-bank = <0x1>;
+                        xlnx,ip-name = "psv_pmc_sd";
+                        xlnx,bus-width = <0x8>;
+                        xlnx,card-detect = <0x0>;
+                        xlnx,has-wp = <0x0>;
+                        xlnx,has-cd = <0x0>;
+                        xlnx,slot-type = <0x3>;
+                        xlnx,clk-50-sdr-otap-dly = <0x4>;
+                        xlnx,clk-50-ddr-itap-dly = <0x0>;
+                        xlnx,has-power = <0x0>;
+                        xlnx,clk-200-sdr-otap-dly = <0x0>;
+                        xlnx,sdio-clk-freq-hz = <0xbebba31>;
+                        xlnx,write-protect = <0x0>;
+                        no-1-8-v;
+                        phandle = <0x2a>;
+                };
+
+                serial0: serial@ff000000 {
+                        compatible = "arm,pl011", "arm,primecell";
+                        status = "okay";
+                        reg = <0x0 0xff000000 0x0 0x1000>;
+                        interrupts = <0x0 0x12 0x4>;
+                        interrupt-parent = <&gic>;
+                        reg-io-width = <0x4>;
+                        clock-names = "uartclk", "apb_pclk";
+                        bootph-all;
+                        clocks = <&versal_clk 0x5c>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224021>;
+                        xlnx,has-modem = <0x0>;
+                        xlnx,uart-clk-freq-hz = <0x5f5dd19>;
+                        port-number = <0x0>;
+                        xlnx,ip-name = "psv_sbsauart";
+                        xlnx,uart-board-interface = "custom";
+                        xlnx,baudrate = <0x1c200>;
+                        cts-override;
+                        u-boot,dm-pre-reloc;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        phandle = <0x4f>;
+                };
+
+                serial1: serial@ff010000 {
+                        compatible = "arm,pl011", "arm,primecell";
+                        status = "disabled";
+                        reg = <0x0 0xff010000 0x0 0x1000>;
+                        interrupts = <0x0 0x13 0x4>;
+                        interrupt-parent = <&gic>;
+                        reg-io-width = <0x4>;
+                        clock-names = "uartclk", "apb_pclk";
+                        bootph-all;
+                        clocks = <&versal_clk 0x5d>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224022>;
+                        phandle = <0xbb>;
+                };
+
+                smmu: iommu@fd800000 {
+                        compatible = "arm,mmu-500";
+                        status = "okay";
+                        reg = <0x0 0xfd800000 0x0 0x40000>;
+                        stream-match-mask = <0x7c00>;
+                        #iommu-cells = <0x1>;
+                        #global-interrupts = <0x1>;
+                        interrupts = <0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4>;
+                        interrupt-parent = <&gic>;
+                        xlnx,ip-name = "psv_fpd_smmutcu";
+                        phandle = <0x4d>;
+                };
+
+                ospi: spi@f1010000 {
+                        compatible = "xlnx,versal-ospi-1.0", "cdns,qspi-nor";
+                        status = "disabled";
+                        reg = <0x0 0xf1010000 0x0 0x10000 0x0 0xc0000000 0x0 0x20000000>;
+                        interrupts = <0x0 0x7c 0x4>;
+                        interrupt-parent = <&gic>;
+                        cdns,fifo-depth = <0x100>;
+                        cdns,fifo-width = <0x4>;
+                        cdns,is-dma = <0x1>;
+                        cdns,trigger-address = <0xc0000000>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x3a>;
+                        power-domains = <&versal_firmware 0x1822402a>;
+                        reset-names = "qspi";
+                        resets = <&versal_reset 0xc10402e>;
+                        phandle = <0xbc>;
+                };
+
+                qspi: spi@f1030000 {
+                        compatible = "xlnx,versal-qspi-1.0";
+                        status = "okay";
+                        reg = <0x0 0xf1030000 0x0 0x1000>;
+                        interrupts = <0x0 0x7d 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x39>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822402b>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,baud-rate-div = <0x8>;
+                        num-cs = <0x2>;
+                        xlnx,qspi-clk-freq-hz = <0x11e19751>;
+                        xlnx,bus-width = <0x2>;
+                        xlnx,ip-name = "psv_pmc_qspi";
+                        spi-rx-bus-width = <0x4>;
+                        xlnx,connection-mode = <0x2>;
+                        spi-tx-bus-width = <0x4>;
+                        qspi-fbclk = <0x1>;
+                        xlnx,clock-freq = <0x11e19751>;
+                        xlnx,qspi-baud-rate-div = <0x8>;
+                        xlnx,qspi-mode = <0x2>;
+                        xlnx,qspi-bus-width = <0x2>;
+                        is-dual = <0x1>;
+                        phandle = <0x29>;
+                };
+
+                spi0: spi@ff040000 {
+                        compatible = "cdns,spi-r1p6";
+                        status = "disabled";
+                        reg = <0x0 0xff040000 0x0 0x1000>;
+                        interrupts = <0x0 0x10 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x5e>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401b>;
+                        phandle = <0xbd>;
+                };
+
+                spi1: spi@ff050000 {
+                        compatible = "cdns,spi-r1p6";
+                        status = "disabled";
+                        reg = <0x0 0xff050000 0x0 0x1000>;
+                        interrupts = <0x0 0x11 0x4>;
+                        interrupt-parent = <&gic>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x5f>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401c>;
+                        phandle = <0xbe>;
+                };
+
+                sysmon0: sysmon@f1270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        #io-channel-cells = <0x0>;
+                        reg = <0x0 0xf1270000 0x0 0x4000>;
+                        interrupts = <0x0 0x90 0x4>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        xlnx,nodeid = <0x18224055>;
+                        xlnx,sat-63-desc = "PS , FPD , satellite";
+                        xlnx,sat-34-y = <0x34f8>;
+                        xlnx,sat-17-x = <0x5842>;
+                        xlnx,sat-1-desc = "PMC , system , ADC";
+                        xlnx,sat-9-x = <0x4999>;
+                        xlnx,sat-17-y = <0x1dc4>;
+                        xlnx,sat-19-desc = "Clocking , column , satellite";
+                        xlnx,sat-20-desc = "Clocking , column , satellite";
+                        xlnx,sat-9-y = <0x25ed>;
+                        xlnx,sat-38-x = <0xae9>;
+                        xlnx,sat-38-y = <0x2ff0>;
+                        xlnx,sat-32-desc = "VNOC , satellite";
+                        xlnx,sat-22-x = <0x3a6a>;
+                        xlnx,ip-name = "psv_pmc_sysmon";
+                        xlnx,sat-22-y = <0x19f9>;
+                        xlnx,sat-16-desc = "Clocking , column , satellite";
+                        xlnx,sat-9-desc = "VNOC , satellite";
+                        xlnx,sat-26-x = <0x2b3b>;
+                        xlnx,sat-28-desc = "VNOC , satellite";
+                        xlnx,sat-26-y = <0xe06>;
+                        xlnx,sat-10-x = <0x48b8>;
+                        xlnx,sat-64-x = <0xc>;
+                        xlnx,sat-2-x = <0xc>;
+                        xlnx,sat-10-y = <0x34f8>;
+                        xlnx,sat-64-y = <0xb34>;
+                        xlnx,sat-2-y = <0xb34>;
+                        xlnx,sat-13-desc = "ME , satellite";
+                        xlnx,sat-41-desc = "Clocking , column , satellite";
+                        xlnx,sat-31-x = <0x1c0c>;
+                        xlnx,sat-6-desc = "XPIO , satellite";
+                        xlnx,sat-31-y = <0xe06>;
+                        xlnx,sat-14-x = <0x5842>;
+                        xlnx,sat-6-x = <0x5833>;
+                        xlnx,sat-25-desc = "ME , satellite";
+                        xlnx,sat-14-y = <0x2ff0>;
+                        xlnx,sat-6-y = <0x5ff>;
+                        xlnx,sat-35-x = <0x123a>;
+                        xlnx,sat-10-desc = "ME , satellite";
+                        xlnx,sat-37-desc = "ME , satellite";
+                        xlnx,sat-35-y = <0x34f8>;
+                        xlnx,sat-18-x = <0x5842>;
+                        xlnx,sat-3-desc = "XPIO , satellite";
+                        xlnx,sat-18-y = <0x1795>;
+                        xlnx,sat-22-desc = "VNOC , satellite";
+                        xlnx,sat-40-x = <0xae9>;
+                        xlnx,sat-39-x = <0xae9>;
+                        xlnx,sat-40-y = <0x2389>;
+                        xlnx,sat-39-y = <0x29b7>;
+                        xlnx,sat-23-x = <0x3a6a>;
+                        xlnx,sat-34-desc = "ME , satellite";
+                        xlnx,sat-23-y = <0x25ed>;
+                        xlnx,sat-18-desc = "Clocking , column , satellite";
+                        xlnx,sat-27-x = <0x2b3b>;
+                        xlnx,sat-27-y = <0x19f9>;
+                        xlnx,sat-11-x = <0x40ef>;
+                        xlnx,sat-3-x = <0x1153>;
+                        xlnx,sat-31-desc = "VNOC , satellite";
+                        xlnx,sat-11-y = <0x34f8>;
+                        xlnx,sat-3-y = <0x5ff>;
+                        status = "okay";
+                        xlnx,sat-32-x = <0x1c0c>;
+                        xlnx,sat-15-desc = "Clocking , column , satellite";
+                        xlnx,sat-32-y = <0x19f9>;
+                        xlnx,sat-15-x = <0x5842>;
+                        xlnx,sat-8-desc = "VNOC , satellite";
+                        xlnx,sat-7-x = <0x4999>;
+                        xlnx,sat-15-y = <0x29b7>;
+                        xlnx,sat-7-y = <0xe06>;
+                        xlnx,sat-27-desc = "VNOC , satellite";
+                        xlnx,sat-36-x = <0xa71>;
+                        xlnx,sat-36-y = <0x34f8>;
+                        xlnx,sat-12-desc = "ME , satellite";
+                        xlnx,sat-19-x = <0x5842>;
+                        xlnx,sat-20-x = <0x5842>;
+                        xlnx,sat-40-desc = "Clocking , column , satellite";
+                        xlnx,sat-39-desc = "Clocking , column , satellite";
+                        xlnx,sat-19-y = <0x11d0>;
+                        xlnx,sat-20-y = <0xba1>;
+                        xlnx,sat-5-desc = "XPIO , satellite";
+                        xlnx,sat-41-x = <0xae9>;
+                        xlnx,sat-24-desc = "ME , satellite";
+                        xlnx,sat-41-y = <0x1dc4>;
+                        xlnx,sat-24-x = <0x3926>;
+                        xlnx,sat-24-y = <0x34f8>;
+                        xlnx,sat-36-desc = "ME , satellite";
+                        xlnx,sat-64-desc = "PS , LPD , satellite";
+                        xlnx,sat-2-desc = "PMC , user , ADC";
+                        xlnx,sat-28-x = <0x2b3b>;
+                        xlnx,sat-21-desc = "VNOC , satellite";
+                        xlnx,sat-28-y = <0x25ed>;
+                        xlnx,sat-12-x = <0x5081>;
+                        xlnx,sat-4-x = <0x28f3>;
+                        xlnx,sat-12-y = <0x34f8>;
+                        xlnx,sat-4-y = <0x5ff>;
+                        xlnx,sat-33-desc = "VNOC , satellite";
+                        xlnx,sat-33-x = <0x1c0c>;
+                        xlnx,sat-33-y = <0x25ed>;
+                        xlnx,sat-16-x = <0x5842>;
+                        xlnx,sat-17-desc = "Clocking , column , satellite";
+                        xlnx,sat-8-x = <0x4999>;
+                        xlnx,sat-16-y = <0x2389>;
+                        xlnx,sat-8-y = <0x19f9>;
+                        xlnx,sat-37-x = <0x2a8>;
+                        xlnx,sat-30-desc = "ME , satellite";
+                        xlnx,sat-29-desc = "ME , satellite";
+                        xlnx,sat-37-y = <0x34f8>;
+                        xlnx,sat-21-x = <0x3a6a>;
+                        xlnx,sat-14-desc = "Clocking , column , satellite";
+                        xlnx,sat-21-y = <0xe06>;
+                        xlnx,sat-7-desc = "VNOC , satellite";
+                        xlnx,sat-26-desc = "VNOC , satellite";
+                        xlnx,sat-25-x = <0x315e>;
+                        xlnx,sat-25-y = <0x34f8>;
+                        xlnx,sat-63-x = <0xc>;
+                        xlnx,sat-11-desc = "ME , satellite";
+                        xlnx,sat-1-x = <0xc>;
+                        xlnx,sat-63-y = <0xb34>;
+                        xlnx,sat-38-desc = "Clocking , column , satellite";
+                        xlnx,sat-1-y = <0xb34>;
+                        xlnx,sat-4-desc = "XPIO , satellite";
+                        xlnx,sat-30-x = <0x21cc>;
+                        xlnx,sat-29-x = <0x2995>;
+                        xlnx,sat-30-y = <0x34f8>;
+                        xlnx,sat-29-y = <0x34f8>;
+                        xlnx,sat-13-x = <0x584a>;
+                        xlnx,sat-23-desc = "VNOC , satellite";
+                        xlnx,sat-5-x = <0x4093>;
+                        xlnx,sat-13-y = <0x34f8>;
+                        xlnx,sat-5-y = <0x5ff>;
+                        xlnx,sat-35-desc = "ME , satellite";
+                        xlnx,sat-34-x = <0x1a03>;
+                        phandle = <0x37>;
+                };
+
+                sysmon1: sysmon@109270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x9270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18225055>;
+                        phandle = <0xbf>;
+                };
+
+                sysmon2: sysmon@111270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x11270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18226055>;
+                        phandle = <0xc0>;
+                };
+
+                sysmon3: sysmon@119270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x19270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18227055>;
+                        phandle = <0xc1>;
+                };
+
+                ttc0: timer@ff0e0000 {
+                        compatible = "cdns,ttc";
+                        status = "okay";
+                        interrupts = <0x0 0x25 0x4 0x0 0x26 0x4 0x0 0x27 0x4>;
+                        interrupt-parent = <&gic>;
+                        reg = <0x0 0xff0e0000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x27>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224024>;
+                        xlnx,ttc-clk2-clksrc = <0x0>;
+                        xlnx,ip-name = "psv_ttc";
+                        xlnx,ttc-clk1-clksrc = <0x0>;
+                        xlnx,ttc-clk0-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-clk1-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-clk2-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-board-interface = "custom";
+                        xlnx,clock-freq = <0x8f0cba9>;
+                        xlnx,ttc-clk0-clksrc = <0x0>;
+                        phandle = <0x55>;
+                };
+
+                ttc1: timer@ff0f0000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x28 0x4 0x0 0x29 0x4 0x0 0x2a 0x4>;
+                        interrupt-parent = <&gic>;
+                        reg = <0x0 0xff0f0000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x28>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224025>;
+                        phandle = <0xc2>;
+                };
+
+                ttc2: timer@ff100000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x2b 0x4 0x0 0x2c 0x4 0x0 0x2d 0x4>;
+                        interrupt-parent = <&gic>;
+                        reg = <0x0 0xff100000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x29>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224026>;
+                        phandle = <0xc3>;
+                };
+
+                ttc3: timer@ff110000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x2e 0x4 0x0 0x2f 0x4 0x0 0x30 0x4>;
+                        interrupt-parent = <&gic>;
+                        reg = <0x0 0xff110000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x2a>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224027>;
+                        phandle = <0xc4>;
+                };
+
+                usb0: usb@ff9d0000 {
+                        compatible = "xlnx,versal-dwc3";
+                        status = "okay";
+                        reg = <0x0 0xff9d0000 0x0 0x100>;
+                        clock-names = "bus_clk", "ref_clk";
+                        ranges;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        clocks = <&versal_clk 0x5b>,
+                         <&versal_clk 0x68>;
+                        power-domains = <&versal_firmware 0x18224018>;
+                        resets = <&versal_reset 0xc104036>;
+                        xlnx,ip-name = "psv_usb";
+                        phandle = <0x60>;
+
+                        dwc3_0: usb@fe200000 {
+                                compatible = "snps,dwc3";
+                                status = "okay";
+                                reg = <0x0 0xfe200000 0x0 0x10000>;
+                                interrupt-names = "host", "peripheral", "otg", "wakeup";
+                                interrupts = <0x0 0x16 0x4 0x0 0x16 0x4 0x0 0x1a 0x4 0x0 0x4a 0x4>;
+                                snps,dis_u2_susphy_quirk;
+                                snps,dis_u3_susphy_quirk;
+                                snps,quirk-frame-length-adjustment = <0x20>;
+                                clock-names = "ref";
+                                clocks = <&versal_clk 0x5b>;
+                                xlnx,is-cache-coherent = <0x0>;
+                                xlnx,ip-name = "psv_usb_xhci";
+                                dr_mode = "host";
+                                maximum-speed = "high-speed";
+                                snps,usb3_lpm_capable;
+                                phandle = <0x4e>;
+                        };
+                };
+
+                cpm_pciea: pci@fca10000 {
+                        device_type = "pci";
+                        #address-cells = <0x3>;
+                        #interrupt-cells = <0x1>;
+                        #size-cells = <0x2>;
+                        compatible = "xlnx,versal-cpm-host-1.00";
+                        status = "okay";
+                        interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc_0 0x0>,
+                         <0x0 0x0 0x0 0x2 &pcie_intc_0 0x1>,
+                         <0x0 0x0 0x0 0x3 &pcie_intc_0 0x2>,
+                         <0x0 0x0 0x0 0x4 &pcie_intc_0 0x3>;
+                        interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+                        interrupt-names = "misc";
+                        interrupts = <0x0 0x48 0x4>;
+                        xlnx,csr-slcr = <0x6 0x0>;
+                        xlnx,num-of-bars = <0x2>;
+                        xlnx,port-type = <0x1>;
+                        interrupt-parent = <&gic>;
+                        bus-range = <0x0 0xff>;
+                        ranges = <0x2000000 0x0 0xe0010000 0x0 0xe0010000 0x0 0x10000000 0x43000000 0x80 0x0 0x80 0x0 0x0 0x80000000>;
+                        msi-map = <0x0 0x4 0x0 0x10000>;
+                        reg = <0x6 0x0 0x0 0x1000000 0x0 0xfca10000 0x0 0x1000>;
+                        reg-names = "cfg", "cpm_slcr";
+                        xlnx,cpm5-slcr-addr = <0xfcdd0000>;
+                        xlnx,ip-name = "psv_cpm";
+                        xlnx,cpm-slcr = <0xfca10000>;
+                        xlnx,cpm5-dma0-csr-addr = <0xfce20000>;
+                        phandle = <0x41>;
+
+                        pcie_intc_0: interrupt-controller {
+                                #address-cells = <0x0>;
+                                #interrupt-cells = <0x1>;
+                                interrupt-controller;
+                                phandle = <0x98>;
+                        };
+                };
+
+                cpm5_pcie: pcie@fcdd0000 {
+                        device_type = "pci";
+                        #address-cells = <0x3>;
+                        #interrupt-cells = <0x1>;
+                        #size-cells = <0x2>;
+                        compatible = "xlnx,versal-cpm5-host";
+                        status = "disabled";
+                        interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc_2 0x0>,
+                         <0x0 0x0 0x0 0x2 &pcie_intc_2 0x1>,
+                         <0x0 0x0 0x0 0x3 &pcie_intc_2 0x2>,
+                         <0x0 0x0 0x0 0x4 &pcie_intc_2 0x3>;
+                        interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+                        interrupt-names = "misc";
+                        interrupts = <0x0 0x48 0x4>;
+                        xlnx,csr-slcr = <0xfce20000>;
+                        xlnx,num-of-bars = <0x2>;
+                        xlnx,port-type = <0x1>;
+                        interrupt-parent = <&gic>;
+                        bus-range = <0x0 0xff>;
+                        ranges = <0x2000000 0x0 0xe0000000 0x0 0xe0000000 0x0 0x10000000 0x43000000 0x80 0x0 0x80 0x0 0x0 0x80000000>;
+                        msi-map = <0x0 0x4 0x0 0x10000>;
+                        reg = <0x6 0x0 0x0 0x1000000 0x0 0xfcdd0000 0x0 0x1000 0x0 0xfce20000 0x0 0x1000000>;
+                        reg-names = "cfg", "cpm_slcr", "cpm_csr";
+                        phandle = <0xc5>;
+
+                        pcie_intc_2: interrupt-controller {
+                                #address-cells = <0x0>;
+                                #interrupt-cells = <0x1>;
+                                interrupt-controller;
+                                phandle = <0x99>;
+                        };
+                };
+
+                watchdog: watchdog@fd4d0000 {
+                        compatible = "xlnx,versal-wwdt";
+                        status = "disabled";
+                        reg = <0x0 0xfd4d0000 0x0 0x10000>;
+                        interrupt-names = "wdt", "wwdt_reset_pending", "gwdt", "gwdt_reset_pending";
+                        interrupts = <0x0 0x64 0x1 0x0 0x6d 0x1 0x0 0x6c 0x1 0x0 0x6e 0x1>;
+                        interrupt-parent = <&gic>;
+                        timeout-sec = <0x1e>;
+                        clocks = <&versal_clk 0x4c>;
+                        power-domains = <&versal_firmware 0x18224029>;
+                        phandle = <0xc6>;
+                };
+
+                watchdog1: watchdog@ff120000 {
+                        compatible = "xlnx,versal-wwdt";
+                        status = "disabled";
+                        reg = <0x0 0xff120000 0x0 0x10000>;
+                        interrupt-parent = <&gic>;
+                        interrupt-names = "wdt", "wwdt_reset_pending", "gwdt", "gwdt_reset_pending";
+                        interrupts = <0x0 0x31 0x1 0x0 0x45 0x1 0x0 0x46 0x4 0x0 0x47 0x4>;
+                        timeout-sec = <0x1e>;
+                        clocks = <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224028>;
+                        phandle = <0xc7>;
+                };
+
+                xilsem_edac: edac@f2014050 {
+                        compatible = "xlnx,versal-xilsem-edac";
+                        status = "disabled";
+                        reg = <0x0 0xf2014050 0x0 0xc4>;
+                        phandle = <0xc8>;
+                };
+
+                dma0: pmcdma@f11c0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-csudma-1.0";
+                        interrupt-parent = <&gic>;
+                        interrupts = <0x0 0x83 0x4>;
+                        reg = <0x0 0xf11c0000 0x0 0x10000>;
+                        xlnx,dma-type = <0x1>;
+                        xlnx,ip-name = "psv_pmc_dma";
+                        phandle = <0x2c>;
+                };
+
+                dma1: pmcdma@f11d0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-csudma-1.0";
+                        interrupt-parent = <&gic>;
+                        interrupts = <0x0 0x84 0x4>;
+                        reg = <0x0 0xf11d0000 0x0 0x10000>;
+                        xlnx,dma-type = <0x2>;
+                        xlnx,ip-name = "psv_pmc_dma";
+                        phandle = <0x2d>;
+                };
+
+                coresight: coresight@f0800000 {
+                        compatible = "xlnx,coresight-1.0";
+                        status = "okay";
+                        reg = <0x0 0xf0800000 0x0 0x10000>;
+                        xlnx,ip-name = "psv_coresight";
+                        phandle = <0xf>;
+                };
+
+                gic: interrupt-controller@f9000000 {
+                        phandle = <0x40>;
+                        xlnx,ip-name = "psv_acpu_gic";
+                        xlnx,apu-gic-its-ctl = <0xf9020000>;
+                        status = "okay";
+                        interrupts = <0x1 0x9 0x4>;
+                        interrupt-parent = <&gic>;
+                        interrupt-controller;
+                        reg = <0x0 0xf9000000 0x0 0x80000 0x0 0xf9080000 0x0 0x80000>;
+                        ranges;
+                        #size-cells = <0x2>;
+                        #address-cells = <0x2>;
+                        #interrupt-cells = <0x3>;
+                        compatible = "arm,gic-v3";
+
+                        gic_its: msi-controller@f9020000 {
+                                phandle = <0x4>;
+                                reg = <0x0 0xf9020000 0x0 0x20000>;
+                                #msi-cells = <0x1>;
+                                msi-controller;
+                                status = "okay";
+                                compatible = "arm,gic-v3-its";
+                        };
+                };
+        };
+
+        amba_xppu: indirect-bus@1 {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0x136>;
+
+                lpd_xppu: xppu@ff990000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xff990000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_xppu";
+                        phandle = <0x5d>;
+                };
+
+                pmc_xppu: xppu@f1310000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf1310000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_xppu";
+                        phandle = <0x3d>;
+                };
+
+                pmc_xppu_npi: xppu@f1300000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf1300000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_xppu_npi";
+                        phandle = <0x3c>;
+                };
+        };
+
+        amba_xmpu: indirect-bus@2 {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0x137>;
+
+                fpd_xmpu: xmpu@fd390000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xfd390000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_slave_xmpu";
+                        phandle = <0x46>;
+                };
+
+                pmc_xmpu: xmpu@f12f0000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf12f0000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_xmpu";
+                        phandle = <0x3b>;
+                };
+
+                ocm_xmpu: xmpu@ff980000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xff980000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,ip-name = "psv_ocm_xmpu";
+                        phandle = <0x5c>;
+                };
+
+                ddrmc_xmpu_1: xmpu@f6220000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6220000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x139>;
+                };
+
+                ddrmc_xmpu_2: xmpu@f6390000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6390000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x13a>;
+                };
+
+                ddrmc_xmpu_3: xmpu@f6500000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6500000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x13b>;
+                };
+        };
+
+        pl_alt_ref_clk: pl_alt_ref_clk {
+                bootph-all;
+                compatible = "fixed-clock";
+                #clock-cells = <0x0>;
+                clock-frequency = <0x1fca055>;
+                phandle = <0x9b>;
+        };
+
+        ref_clk: ref_clk {
+                bootph-all;
+                compatible = "fixed-clock";
+                #clock-cells = <0x0>;
+                clock-frequency = <0x1fca055>;
+                phandle = <0x9a>;
+        };
+
+        can0_clk: can0_clk {
+                #clock-cells = <0x0>;
+                compatible = "fixed-factor-clock";
+                clocks = <&versal_clk 0x60>;
+                clock-div = <0x2>;
+                clock-mult = <0x1>;
+                phandle = <0x92>;
+        };
+
+        can1_clk: can1_clk {
+                #clock-cells = <0x0>;
+                compatible = "fixed-factor-clock";
+                clocks = <&versal_clk 0x61>;
+                clock-div = <0x2>;
+                clock-mult = <0x1>;
+                phandle = <0x93>;
+        };
+
+        firmware {
+
+                versal_firmware: versal-firmware {
+                        compatible = "xlnx,versal-firmware";
+                        interrupt-parent = <&gic>;
+                        bootph-all;
+                        method = "smc";
+                        #power-domain-cells = <0x1>;
+                        phandle = <0x75>;
+
+                        versal_clk: clock-controller {
+                                bootph-all;
+                                #clock-cells = <0x1>;
+                                compatible = "xlnx,versal-clk";
+                                clocks = <&ref_clk>,
+                                 <&pl_alt_ref_clk>;
+                                clock-names = "ref_clk", "pl_alt_ref_clk";
+                                phandle = <0x76>;
+                        };
+
+                        zynqmp_power: zynqmp-power {
+                                compatible = "xlnx,zynqmp-power";
+                                phandle = <0x13c>;
+                        };
+
+                        versal_reset: reset-controller {
+                                compatible = "xlnx,versal-reset";
+                                #reset-cells = <0x1>;
+                                phandle = <0x97>;
+                        };
+
+                        pinctrl0: pinctrl {
+                                compatible = "xlnx,versal-pinctrl";
+                                phandle = <0x13d>;
+                        };
+
+                        versal_sec_cfg: versal-sec-cfg {
+                                compatible = "xlnx,versal-sec-cfg";
+                                #address-cells = <0x1>;
+                                #size-cells = <0x1>;
+                                phandle = <0x13e>;
+
+                                bbram_zeroize: bbram-zeroize@4 {
+                                        reg = <0x4 0x4>;
+                                        phandle = <0x13f>;
+                                };
+
+                                bbram_key: bbram-key@10 {
+                                        reg = <0x10 0x20>;
+                                        phandle = <0x140>;
+                                };
+
+                                bbram_usr: bbram-usr@30 {
+                                        reg = <0x30 0x4>;
+                                        phandle = <0x141>;
+                                };
+
+                                bbram_lock: bbram-lock@48 {
+                                        reg = <0x48 0x4>;
+                                        phandle = <0x142>;
+                                };
+
+                                user_key0: user-key@110 {
+                                        reg = <0x110 0x20>;
+                                        phandle = <0x143>;
+                                };
+
+                                user_key1: user-key@130 {
+                                        reg = <0x130 0x20>;
+                                        phandle = <0x144>;
+                                };
+
+                                user_key2: user-key@150 {
+                                        reg = <0x150 0x20>;
+                                        phandle = <0x145>;
+                                };
+
+                                user_key3: user-key@170 {
+                                        reg = <0x170 0x20>;
+                                        phandle = <0x146>;
+                                };
+
+                                user_key4: user-key@190 {
+                                        reg = <0x190 0x20>;
+                                        phandle = <0x147>;
+                                };
+
+                                user_key5: user-key@1b0 {
+                                        reg = <0x1b0 0x20>;
+                                        phandle = <0x148>;
+                                };
+
+                                user_key6: user-key@1d0 {
+                                        reg = <0x1d0 0x20>;
+                                        phandle = <0x149>;
+                                };
+
+                                user_key7: user-key@1f0 {
+                                        reg = <0x1f0 0x20>;
+                                        phandle = <0x14a>;
+                                };
+                        };
+                };
+        };
+
+        amba_pl: amba_pl {
+                ranges;
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                firmware-name = "qdma-example-kula-vmk180-20260526.pdi";
+                phandle = <0x14b>;
+
+                misc_clk_0: misc_clk_0 {
+                        compatible = "fixed-clock";
+                        clock-frequency = <0xee6b280>;
+                        #clock-cells = <0x0>;
+                        phandle = <0x9c>;
+                };
+
+                axi_gpio_0: gpio@20200000000 {
+                        #interrupt-cells = <0x2>;
+                        interrupts = <0x0 0x5d 0x4>;
+                        xlnx,gpio-board-interface = "Custom";
+                        compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+                        xlnx,all-outputs = <0x0>;
+                        #gpio-cells = <0x2>;
+                        xlnx,gpio-width = <0x20>;
+                        interrupt-parent = <&gic>;
+                        xlnx,dout-default = <0x0>;
+                        xlnx,is-dual = <0x1>;
+                        xlnx,ip-name = "axi_gpio";
+                        xlnx,tri-default-2 = <0xffffffff>;
+                        reg = <0x202 0x0 0x0 0x10000>;
+                        xlnx,all-inputs-2 = <0x0>;
+                        clocks = <&misc_clk_0>;
+                        xlnx,all-outputs-2 = <0x1>;
+                        gpio-controller;
+                        xlnx,interrupt-present = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,dout-default-2 = <0x0>;
+                        status = "okay";
+                        xlnx,gpio2-width = <0x20>;
+                        clock-names = "s_axi_aclk";
+                        interrupt-controller;
+                        interrupt-names = "ip2intc_irpt";
+                        xlnx,tri-default = <0xffffffff>;
+                        xlnx,all-inputs = <0x1>;
+                        phandle = <0x70>;
+                };
+
+                axi_gpio_1: gpio@20200010000 {
+                        #interrupt-cells = <0x2>;
+                        xlnx,gpio-board-interface = "Custom";
+                        compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+                        xlnx,all-outputs = <0x0>;
+                        #gpio-cells = <0x2>;
+                        xlnx,gpio-width = <0x20>;
+                        xlnx,dout-default = <0x0>;
+                        xlnx,is-dual = <0x1>;
+                        xlnx,ip-name = "axi_gpio";
+                        xlnx,tri-default-2 = <0xffffffff>;
+                        reg = <0x202 0x10000 0x0 0x10000>;
+                        xlnx,all-inputs-2 = <0x0>;
+                        clocks = <&misc_clk_0>;
+                        xlnx,all-outputs-2 = <0x1>;
+                        gpio-controller;
+                        xlnx,interrupt-present = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,dout-default-2 = <0x0>;
+                        status = "okay";
+                        xlnx,gpio2-width = <0x20>;
+                        clock-names = "s_axi_aclk";
+                        interrupt-controller;
+                        xlnx,tri-default = <0xffffffff>;
+                        xlnx,all-inputs = <0x1>;
+                        phandle = <0x71>;
+                };
+
+                mailbox_0: mailbox@20180000000 {
+                        interrupts = <0x0 0x5c 0x4>;
+                        xlnx,s1-axi-aclk-freq-mhz = <0xfa>;
+                        compatible = "xlnx,mailbox-2.1";
+                        xlnx,interconnect-port-0 = <0x2>;
+                        xlnx,interconnect-port-1 = <0x2>;
+                        interrupt-parent = <&gic>;
+                        xlnx,mailbox-depth = <0x40>;
+                        xlnx,s1-axi-data-width = <0x20>;
+                        xlnx,s0-axi-addr-width = <0x20>;
+                        xlnx,ip-name = "mailbox";
+                        reg = <0x201 0x80000000 0x0 0x10000 0x201 0x80010000 0x0 0x10000>;
+                        xlnx,async-clks = <0x0>;
+                        xlnx,impl-style = <0x0>;
+                        clocks = <&misc_clk_0>,
+                         <&misc_clk_0>;
+                        xlnx,read-clock-period-0 = <0x0>;
+                        xlnx,read-clock-period-1 = <0x0>;
+                        xlnx,num-sync-ff = <0x2>;
+                        xlnx,async-interrupts = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,enable-bus-error = <0x0>;
+                        xlnx,s0-axi-data-width = <0x20>;
+                        status = "okay";
+                        xlnx,ext-reset-high = <0x1>;
+                        clock-names = "S0_AXI_ACLK", "S1_AXI_ACLK";
+                        interrupt-names = "Interrupt_0";
+                        xlnx,s1-axi-addr-width = <0x20>;
+                        xlnx,s0-axi-aclk-freq-mhz = <0xfa>;
+                        phandle = <0x6f>;
+                };
+
+                pcie_qdma_mailbox_0: pcie_qdma_mailbox@20800000000 {
+                        xlnx,num-vfs-pf3 = <0x3c>;
+                        compatible = "xlnx,pcie-qdma-mailbox-1.0";
+                        xlnx,patch-revision = <0x20140001>;
+                        xlnx,rtl-revision = <0x1fd31000>;
+                        xlnx,h10-device = <0x0>;
+                        xlnx,ip-name = "pcie_qdma_mailbox";
+                        xlnx,total-fnc = <0x100>;
+                        reg = <0x208 0x0 0x0 0x80000000>;
+                        clocks = <&misc_clk_0>,
+                         <&misc_clk_0>;
+                        xlnx,max-pf = <0x4>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mailbox-opt;
+                        xlnx,versal;
+                        status = "okay";
+                        xlnx,num-pfs = <0x4>;
+                        clock-names = "axi_aclk", "ip_clk";
+                        xlnx,num-vfs-pf0 = <0x40>;
+                        xlnx,num-vfs-pf1 = <0x40>;
+                        xlnx,vf-4kq = <0x0>;
+                        xlnx,num-vfs-pf2 = <0x40>;
+                        phandle = <0x72>;
+                };
+        };
+
+        axi_noc_0_ddr_memory: memory@00000000 {
+                compatible = "xlnx,axi-noc-1.1";
+                xlnx,ip-name = "axi_noc";
+                device_type = "memory";
+                reg = <0x0 0x0 0x0 0x80000000>;
+                memory_type = "memory";
+                phandle = <0x3>;
+        };
+
+        chosen {
+                stdout-path = "serial0:115200";
+                bootargs = "console=ttyAMA0 earlycon=pl011,mmio32,0xFF000000,115200n8 clk_ignore_unused";
+        };
+
+        aliases {
+                serial0 = "/axi/serial@ff000000";
+                spi0 = "/axi/spi@f1030000";
+                serial1 = "/axi/coresight@f0800000";
+                i2c0 = "/axi/i2c@ff020000";
+                ethernet0 = "/axi/ethernet@ff0c0000";
+                serial2 = "/dcc";
+                ethernet1 = "/axi/ethernet@ff0d0000";
+                i2c1 = "/axi/i2c@ff030000";
+                mmc0 = "/axi/mmc@f1050000";
+                usb0 = "/axi/usb@ff9d0000";
+                rtc0 = "/axi/rtc@f12a0000";
+        };
+
+        __symbols__ {
+                cpus_a72 = "/cpus-a72@0";
+                psv_cortexa72_0 = "/cpus-a72@0/cpu@0";
+                psv_cortexa72_1 = "/cpus-a72@0/cpu@1";
+                CPU_SLEEP_0 = "/cpus-a72@0/idle-states/cpu-sleep-0";
+                cpu_opp_table = "/opp-table-cpu";
+                dcc = "/dcc";
+                fpga = "/fpga-region";
+                psci = "/psci";
+                timer = "/timer";
+                versal_fpga = "/versal-fpga";
+                sensor0 = "/versal-thermal-sensor";
+                versal_thermal = "/thermal-zones/versal-thermal";
+                temp_alert = "/thermal-zones/versal-thermal/trips/temp-alert";
+                ot_crit = "/thermal-zones/versal-thermal/trips/ot-crit";
+                amba_apu = "/apu-bus";
+                gic_its = "/axi/interrupt-controller@f9000000/msi-controller@f9020000";
+                amba = "/axi";
+                imux = "/axi/interrupt-multiplex";
+                can0 = "/axi/can@ff060000";
+                can1 = "/axi/can@ff070000";
+                cci = "/axi/cci@fd000000";
+                cci_pmu = "/axi/cci@fd000000/pmu@10000";
+                lpd_dma_chan0 = "/axi/dma-controller@ffa80000";
+                lpd_dma_chan1 = "/axi/dma-controller@ffa90000";
+                lpd_dma_chan2 = "/axi/dma-controller@ffaa0000";
+                lpd_dma_chan3 = "/axi/dma-controller@ffab0000";
+                lpd_dma_chan4 = "/axi/dma-controller@ffac0000";
+                lpd_dma_chan5 = "/axi/dma-controller@ffad0000";
+                lpd_dma_chan6 = "/axi/dma-controller@ffae0000";
+                lpd_dma_chan7 = "/axi/dma-controller@ffaf0000";
+                gem0 = "/axi/ethernet@ff0c0000";
+                mdio = "/axi/ethernet@ff0c0000/mdio";
+                phy1 = "/axi/ethernet@ff0c0000/mdio/ethernet-phy@1";
+                phy2 = "/axi/ethernet@ff0c0000/mdio/ethernet-phy@2";
+                gem1 = "/axi/ethernet@ff0d0000";
+                gpio0 = "/axi/gpio@ff0b0000";
+                gpio1 = "/axi/gpio@f1020000";
+                i2c0 = "/axi/i2c@ff020000";
+                i2c1 = "/axi/i2c@ff030000";
+                i2c2 = "/axi/i2c@f1000000";
+                mc1 = "/axi/memory-controller@f62c0000";
+                mc2 = "/axi/memory-controller@f6430000";
+                mc3 = "/axi/memory-controller@f65a0000";
+                ocm = "/axi/memory-controller@ff960000";
+                rtc = "/axi/rtc@f12a0000";
+                sdhci0 = "/axi/mmc@f1040000";
+                sdhci1 = "/axi/mmc@f1050000";
+                serial0 = "/axi/serial@ff000000";
+                serial1 = "/axi/serial@ff010000";
+                smmu = "/axi/iommu@fd800000";
+                ospi = "/axi/spi@f1010000";
+                qspi = "/axi/spi@f1030000";
+                spi0 = "/axi/spi@ff040000";
+                spi1 = "/axi/spi@ff050000";
+                sysmon0 = "/axi/sysmon@f1270000";
+                sysmon1 = "/axi/sysmon@109270000";
+                sysmon2 = "/axi/sysmon@111270000";
+                sysmon3 = "/axi/sysmon@119270000";
+                ttc0 = "/axi/timer@ff0e0000";
+                ttc1 = "/axi/timer@ff0f0000";
+                ttc2 = "/axi/timer@ff100000";
+                ttc3 = "/axi/timer@ff110000";
+                usb0 = "/axi/usb@ff9d0000";
+                dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
+                cpm_pciea = "/axi/pci@fca10000";
+                pcie_intc_0 = "/axi/pci@fca10000/interrupt-controller";
+                cpm5_pcie = "/axi/pcie@fcdd0000";
+                pcie_intc_2 = "/axi/pcie@fcdd0000/interrupt-controller";
+                watchdog = "/axi/watchdog@fd4d0000";
+                watchdog1 = "/axi/watchdog@ff120000";
+                xilsem_edac = "/axi/edac@f2014050";
+                dma0 = "/axi/pmcdma@f11c0000";
+                dma1 = "/axi/pmcdma@f11d0000";
+                coresight = "/axi/coresight@f0800000";
+                amba_xppu = "/indirect-bus@1";
+                lpd_xppu = "/indirect-bus@1/xppu@ff990000";
+                pmc_xppu = "/indirect-bus@1/xppu@f1310000";
+                pmc_xppu_npi = "/indirect-bus@1/xppu@f1300000";
+                amba_xmpu = "/indirect-bus@2";
+                fpd_xmpu = "/indirect-bus@2/xmpu@fd390000";
+                pmc_xmpu = "/indirect-bus@2/xmpu@f12f0000";
+                ocm_xmpu = "/indirect-bus@2/xmpu@ff980000";
+                ddrmc_xmpu_1 = "/indirect-bus@2/xmpu@f6220000";
+                ddrmc_xmpu_2 = "/indirect-bus@2/xmpu@f6390000";
+                ddrmc_xmpu_3 = "/indirect-bus@2/xmpu@f6500000";
+                pl_alt_ref_clk = "/pl_alt_ref_clk";
+                ref_clk = "/ref_clk";
+                can0_clk = "/can0_clk";
+                can1_clk = "/can1_clk";
+                versal_firmware = "/firmware/versal-firmware";
+                versal_clk = "/firmware/versal-firmware/clock-controller";
+                zynqmp_power = "/firmware/versal-firmware/zynqmp-power";
+                versal_reset = "/firmware/versal-firmware/reset-controller";
+                pinctrl0 = "/firmware/versal-firmware/pinctrl";
+                versal_sec_cfg = "/firmware/versal-firmware/versal-sec-cfg";
+                bbram_zeroize = "/firmware/versal-firmware/versal-sec-cfg/bbram-zeroize@4";
+                bbram_key = "/firmware/versal-firmware/versal-sec-cfg/bbram-key@10";
+                bbram_usr = "/firmware/versal-firmware/versal-sec-cfg/bbram-usr@30";
+                bbram_lock = "/firmware/versal-firmware/versal-sec-cfg/bbram-lock@48";
+                user_key0 = "/firmware/versal-firmware/versal-sec-cfg/user-key@110";
+                user_key1 = "/firmware/versal-firmware/versal-sec-cfg/user-key@130";
+                user_key2 = "/firmware/versal-firmware/versal-sec-cfg/user-key@150";
+                user_key3 = "/firmware/versal-firmware/versal-sec-cfg/user-key@170";
+                user_key4 = "/firmware/versal-firmware/versal-sec-cfg/user-key@190";
+                user_key5 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1b0";
+                user_key6 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1d0";
+                user_key7 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1f0";
+                amba_pl = "/amba_pl";
+                misc_clk_0 = "/amba_pl/misc_clk_0";
+                axi_gpio_0 = "/amba_pl/gpio@20200000000";
+                axi_gpio_1 = "/amba_pl/gpio@20200010000";
+                mailbox_0 = "/amba_pl/mailbox@20180000000";
+                pcie_qdma_mailbox_0 = "/amba_pl/pcie_qdma_mailbox@20800000000";
+                axi_noc_0_ddr_memory = "/memory@00000000";
+                gic = "/axi/interrupt-controller@f9000000";
+        };
+};

--- a/meta-nile/conf/dts/kula-vmk180/kula-microblaze-pmc.dts
+++ b/meta-nile/conf/dts/kula-vmk180/kula-microblaze-pmc.dts
@@ -1,0 +1,5731 @@
+/dts-v1/;
+
+/ {
+        compatible = "xlnx,versal-vmk180-revA", "xlnx,versal";
+        #address-cells = <0x2>;
+        #size-cells = <0x2>;
+        model = "Xilinx Versal vmk180 Eval board revA";
+        board = "vmk180";
+        device_id = "xcvm1802";
+        slrcount = <0x1>;
+        family = "Versal";
+
+        options {
+
+                u-boot {
+                        compatible = "u-boot,config";
+                        bootscr-address = <0x0 0x20000000>;
+                };
+        };
+
+        cpus_a72: cpus-a72@0 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0x0 0xf0000000 &amba 0x0 0xf0000000 0x0 0x10000000>,
+                 <0x0 0xf9000000 &amba_apu 0x0 0xf9000000 0x0 0x80000>,
+                 <0x0 0x0 &axi_noc_0_ddr_memory 0x0 0x0 0x0 0x80000000>,
+                 <0x0 0xf9020000 &gic_its 0x0 0xf9020000 0x0 0x20000>,
+                 <0x0 0xff330000 &ipi0 0x0 0xff330000 0x0 0x10000>,
+                 <0x0 0xff340000 &ipi1 0x0 0xff340000 0x0 0x10000>,
+                 <0x0 0xff350000 &ipi2 0x0 0xff350000 0x0 0x10000>,
+                 <0x0 0xff360000 &ipi3 0x0 0xff360000 0x0 0x10000>,
+                 <0x0 0xff370000 &ipi4 0x0 0xff370000 0x0 0x10000>,
+                 <0x0 0xff380000 &ipi5 0x0 0xff380000 0x0 0x10000>,
+                 <0x0 0xff3a0000 &ipi6 0x0 0xff3a0000 0x0 0x10000>,
+                 <0x0 0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0x0 0xfffc0000 0x0 0x40000>,
+                 <0x0 0xe0000000 &versal_cips_0_pspmc_0_psv_noc_pcie_0 0x0 0xe0000000 0x0 0x10000000>,
+                 <0x0 0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0x0 0xf0310000 0x0 0x8000>,
+                 <0x0 0xf0800000 &coresight 0x0 0xf0800000 0x0 0x10000>,
+                 <0x0 0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0x0 0xf0980000 0x0 0x10000>,
+                 <0x0 0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0x0 0xf0b70000 0x0 0x10000>,
+                 <0x0 0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0x0 0xf0b80000 0x0 0x10000>,
+                 <0x0 0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0x0 0xf0c20000 0x0 0x10000>,
+                 <0x0 0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0x0 0xf0c30000 0x0 0x10000>,
+                 <0x0 0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0x0 0xf0c60000 0x0 0x10000>,
+                 <0x0 0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0x0 0xf0ca0000 0x0 0x10000>,
+                 <0x0 0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0x0 0xf0d00000 0x0 0x10000>,
+                 <0x0 0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0x0 0xf0d10000 0x0 0x10000>,
+                 <0x0 0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0x0 0xf0d20000 0x0 0x10000>,
+                 <0x0 0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0x0 0xf0d30000 0x0 0x10000>,
+                 <0x0 0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0x0 0xf0d40000 0x0 0x10000>,
+                 <0x0 0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0x0 0xf0d50000 0x0 0x10000>,
+                 <0x0 0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0x0 0xf0d60000 0x0 0x10000>,
+                 <0x0 0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0x0 0xf0d70000 0x0 0x10000>,
+                 <0x0 0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0x0 0xf0f00000 0x0 0x10000>,
+                 <0x0 0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0x0 0xf0f20000 0x0 0x10000>,
+                 <0x0 0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0x0 0xf0f40000 0x0 0x10000>,
+                 <0x0 0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0x0 0xf0f50000 0x0 0x10000>,
+                 <0x0 0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0x0 0xf0f60000 0x0 0x10000>,
+                 <0x0 0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0x0 0xf0f70000 0x0 0x10000>,
+                 <0x0 0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0x0 0xf0f80000 0x0 0x10000>,
+                 <0x0 0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0x0 0xf0fa0000 0x0 0x10000>,
+                 <0x0 0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0x0 0xf0fd0000 0x0 0x10000>,
+                 <0x0 0xf1000000 &i2c2 0x0 0xf1000000 0x0 0x10000>,
+                 <0x0 0xf1030000 &qspi 0x0 0xf1030000 0x0 0x10000>,
+                 <0x0 0xf1050000 &sdhci1 0x0 0xf1050000 0x0 0x10000>,
+                 <0x0 0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0x0 0xf1110000 0x0 0x50000>,
+                 <0x0 0xf11c0000 &dma0 0x0 0xf11c0000 0x0 0x10000>,
+                 <0x0 0xf11d0000 &dma1 0x0 0xf11d0000 0x0 0x10000>,
+                 <0x0 0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0x0 0xf11e0000 0x0 0x10000>,
+                 <0x0 0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0x0 0xf11f0000 0x0 0x10000>,
+                 <0x0 0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0x0 0xf1200000 0x0 0x10000>,
+                 <0x0 0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0x0 0xf1210000 0x0 0x10000>,
+                 <0x0 0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0x0 0xf1220000 0x0 0x10000>,
+                 <0x0 0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0x0 0xf1230000 0x0 0x10000>,
+                 <0x0 0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0x0 0xf1240000 0x0 0x10000>,
+                 <0x0 0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0x0 0xf1250000 0x0 0x10000>,
+                 <0x0 0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0x0 0xf1260000 0x0 0x10000>,
+                 <0x0 0xf1270000 &sysmon0 0x0 0xf1270000 0x0 0x30000>,
+                 <0x0 0xf12a0000 &rtc 0x0 0xf12a0000 0x0 0x10000>,
+                 <0x0 0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0x0 0xf12b0000 0x0 0x10000>,
+                 <0x0 0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0x0 0xf12d0000 0x0 0x1000>,
+                 <0x0 0xf12f0000 &pmc_xmpu 0x0 0xf12f0000 0x0 0x10000>,
+                 <0x0 0xf1300000 &pmc_xppu_npi 0x0 0xf1300000 0x0 0x10000>,
+                 <0x0 0xf1310000 &pmc_xppu 0x0 0xf1310000 0x0 0x10000>,
+                 <0x0 0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0x0 0xf2100000 0x0 0x10000>,
+                 <0x0 0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0x0 0xf6000000 0x0 0x2000000>,
+                 <0x0 0xf9000000 &gic_a72 0x0 0xf9000000 0x0 0x70000>,
+                 <0x0 0xfca10000 &cpm_pciea 0x0 0xfca10000 0x0 0x5f0000>,
+                 <0x0 0xfd000000 &cci 0x0 0xfd000000 0x0 0x100000>,
+                 <0x0 0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0x0 0xfd1a0000 0x0 0x140000>,
+                 <0x0 0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0x0 0xfd360000 0x0 0x10000>,
+                 <0x0 0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0x0 0xfd380000 0x0 0x10000>,
+                 <0x0 0xfd390000 &fpd_xmpu 0x0 0xfd390000 0x0 0x10000>,
+                 <0x0 0xfd5c0000 &versal_cips_0_pspmc_0_psv_apu_0 0x0 0xfd5c0000 0x0 0x10000>,
+                 <0x0 0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0x0 0xfd5e0000 0x0 0x10000>,
+                 <0x0 0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0x0 0xfd5f0000 0x0 0x10000>,
+                 <0x0 0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0x0 0xfd610000 0x0 0x10000>,
+                 <0x0 0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0x0 0xfd690000 0x0 0x10000>,
+                 <0x0 0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0x0 0xfd700000 0x0 0x100000>,
+                 <0x0 0xfd800000 &smmu 0x0 0xfd800000 0x0 0x800000>,
+                 <0x0 0xfe200000 &dwc3_0 0x0 0xfe200000 0x0 0x100000>,
+                 <0x0 0xff000000 &serial0 0x0 0xff000000 0x0 0x10000>,
+                 <0x0 0xff030000 &i2c1 0x0 0xff030000 0x0 0x10000>,
+                 <0x0 0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0x0 0xff080000 0x0 0x20000>,
+                 <0x0 0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0x0 0xff0a0000 0x0 0x10000>,
+                 <0x0 0xff0b0000 &gpio0 0x0 0xff0b0000 0x0 0x10000>,
+                 <0x0 0xff0c0000 &gem0 0x0 0xff0c0000 0x0 0x10000>,
+                 <0x0 0xff0e0000 &ttc0 0x0 0xff0e0000 0x0 0x10000>,
+                 <0x0 0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0x0 0xff130000 0x0 0x10000>,
+                 <0x0 0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0x0 0xff140000 0x0 0x10000>,
+                 <0x0 0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0x0 0xff410000 0x0 0x100000>,
+                 <0x0 0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0x0 0xff510000 0x0 0x40000>,
+                 <0x0 0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0x0 0xff5e0000 0x0 0x300000>,
+                 <0x0 0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0x0 0xff960000 0x0 0x10000>,
+                 <0x0 0xff980000 &ocm_xmpu 0x0 0xff980000 0x0 0x10000>,
+                 <0x0 0xff990000 &lpd_xppu 0x0 0xff990000 0x0 0x10000>,
+                 <0x0 0xff9a0000 &versal_cips_0_pspmc_0_psv_rpu_0 0x0 0xff9a0000 0x0 0x10000>,
+                 <0x0 0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0x0 0xff9b0000 0x0 0x10000>,
+                 <0x0 0xff9d0000 &usb0 0x0 0xff9d0000 0x0 0x10000>,
+                 <0x0 0xffa80000 &lpd_dma_chan0 0x0 0xffa80000 0x0 0x10000>,
+                 <0x0 0xffa90000 &lpd_dma_chan1 0x0 0xffa90000 0x0 0x10000>,
+                 <0x0 0xffaa0000 &lpd_dma_chan2 0x0 0xffaa0000 0x0 0x10000>,
+                 <0x0 0xffab0000 &lpd_dma_chan3 0x0 0xffab0000 0x0 0x10000>,
+                 <0x0 0xffac0000 &lpd_dma_chan4 0x0 0xffac0000 0x0 0x10000>,
+                 <0x0 0xffad0000 &lpd_dma_chan5 0x0 0xffad0000 0x0 0x10000>,
+                 <0x0 0xffae0000 &lpd_dma_chan6 0x0 0xffae0000 0x0 0x10000>,
+                 <0x0 0xffaf0000 &lpd_dma_chan7 0x0 0xffaf0000 0x0 0x10000>,
+                 <0x0 0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0x0 0xffc90000 0x0 0xf000>,
+                 <0x0 0xffe00000 &psv_r5_0_atcm_global 0x0 0xffe00000 0x0 0x40000>,
+                 <0x0 0xffe90000 &psv_r5_1_atcm_global 0x0 0xffe90000 0x0 0x10000>,
+                 <0x0 0xffeb0000 &psv_r5_1_btcm_global 0x0 0xffeb0000 0x0 0x10000>,
+                 <0x6 0x0 &versal_cips_0_pspmc_0_psv_noc_pcie_1 0x6 0x0 0x2 0x0>,
+                 <0x80 0x0 &versal_cips_0_pspmc_0_psv_noc_pcie_2 0x80 0x0 0x40 0x0>,
+                 <0x201 0x80000000 &mailbox_0 0x201 0x80000000 0x0 0x10000>,
+                 <0x202 0x0 &axi_gpio_0 0x202 0x0 0x0 0x10000>,
+                 <0x202 0x10000 &axi_gpio_1 0x202 0x10000 0x0 0x10000>,
+                 <0x208 0x0 &pcie_qdma_mailbox_0 0x208 0x0 0x0 0x80000000>;
+                #ranges-address-cells = <0x2>;
+                #ranges-size-cells = <0x2>;
+                phandle = <0x9d>;
+
+                psv_cortexa72_0: cpu@0 {
+                        compatible = "arm,cortex-a72", "arm,armv8";
+                        device_type = "cpu";
+                        enable-method = "psci";
+                        operating-points-v2 = <&cpu_opp_table>;
+                        reg = <0x0>;
+                        cpu-idle-states = <&CPU_SLEEP_0>;
+                        power-domains = <&versal_firmware 0x18110003>;
+                        clocks = <&versal_clk 0x4d>;
+                        xlnx,rable = <0x0>;
+                        xlnx,timestamp-clk-freq = <0x5f5dd19>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        stamp-frequency = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_cortexa72";
+                        xlnx,cpu-clk-freq-hz = <0x5372172a>;
+                        cpu-frequency = <0x5372172a>;
+                        bus-handle = <0x1>;
+                        phandle = <0x9e>;
+                };
+
+                psv_cortexa72_1: cpu@1 {
+                        compatible = "arm,cortex-a72", "arm,armv8";
+                        device_type = "cpu";
+                        enable-method = "psci";
+                        operating-points-v2 = <&cpu_opp_table>;
+                        reg = <0x1>;
+                        cpu-idle-states = <&CPU_SLEEP_0>;
+                        power-domains = <&versal_firmware 0x18110004>;
+                        xlnx,rable = <0x0>;
+                        xlnx,timestamp-clk-freq = <0x5f5dd19>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        stamp-frequency = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_cortexa72";
+                        xlnx,cpu-clk-freq-hz = <0x5372172a>;
+                        cpu-frequency = <0x5372172a>;
+                        bus-handle = <0x1>;
+                        phandle = <0x9f>;
+                };
+
+                idle-states {
+                        entry-method = "psci";
+
+                        CPU_SLEEP_0: cpu-sleep-0 {
+                                compatible = "arm,idle-state";
+                                arm,psci-suspend-param = <0x40000000>;
+                                local-timer-stop;
+                                entry-latency-us = <0x12c>;
+                                exit-latency-us = <0x258>;
+                                min-residency-us = <0x2710>;
+                                phandle = <0x74>;
+                        };
+                };
+        };
+
+        cpus_microblaze_0: cpus_microblaze@0 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0x0 &axi_noc_0_ddr_memory 0x0 0x80000000>,
+                 <0xff320000 &ipi_pmc 0xff320000 0x10000>,
+                 <0xff390000 &ipi_pmc_nobuf 0xff390000 0x10000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfca10000 &cpm_pciea 0xfca10000 0x5f0000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0xffe00000 &psv_r5_0_atcm_global 0xffe00000 0x40000>,
+                 <0xffe90000 &psv_r5_1_atcm_global 0xffe90000 0x10000>,
+                 <0xffeb0000 &psv_r5_1_btcm_global 0xffeb0000 0x10000>,
+                 <0xf0083000 &versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0 0xf0083000 0x1000>,
+                 <0xf0200000 &versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr 0xf0200000 0x40000>,
+                 <0xf0240000 &versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr 0xf0240000 0x20000>,
+                 <0xf0280000 &iomodule0 0xf0280000 0x1000>,
+                 <0xf0283000 &versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0 0xf0283000 0x1000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa0>;
+
+                psv_pmc_0: cpu@0 {
+                        compatible = "pmc-microblaze";
+                        device_type = "cpu";
+                        reg = <0x0>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        xlnx,d-axi = <0x1>;
+                        xlnx,addr-tag-bits = <0x0>;
+                        xlnx,m-axi-dc-thread-id-width = <0x1>;
+                        xlnx,m0-axis-protocol = "GENERIC";
+                        xlnx,dcache-force-tag-lutram = <0x0>;
+                        xlnx,interrupt-is-edge = <0x0>;
+                        xlnx,use-mmu = <0x0>;
+                        xlnx,m-axi-dp-exclusive-access = <0x0>;
+                        xlnx,use-reorder-instr = <0x1>;
+                        xlnx,m14-axis-protocol = "GENERIC";
+                        xlnx,use-div = <0x1>;
+                        xlnx,dc-axi-mon = <0x0>;
+                        xlnx,m-axi-ic-user-signals = <0x0>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,s14-axis-protocol = "GENERIC";
+                        xlnx,mmu-zones = <0x10>;
+                        xlnx,enable-discrete-ports = <0x0>;
+                        xlnx,d-lmb = <0x1>;
+                        xlnx,m-axi-dc-exclusive-access = <0x0>;
+                        xlnx,debug-interface = <0x0>;
+                        xlnx,s9-axis-protocol = "GENERIC";
+                        xlnx,sco = <0x0>;
+                        xlnx,use-ext-brk = <0x0>;
+                        xlnx,debug-enabled = <0x1>;
+                        xlnx,daddr-size = <0x20>;
+                        xlnx,s0-axis-data-width = <0x20>;
+                        xlnx,use-extended-fsl-instr = <0x0>;
+                        xlnx,m-axi-dc-user-signals = <0x0>;
+                        xlnx,reset-msr = <0x0>;
+                        xlnx,branch-target-cache-size = <0x0>;
+                        xlnx,s2-axis-data-width = <0x20>;
+                        xlnx,cache-byte-size = <0x2000>;
+                        bus-handle = <0x1>;
+                        xlnx,mmu-tlb-access = <0x3>;
+                        xlnx,s4-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-awuser-width = <0x5>;
+                        xlnx,s6-axis-data-width = <0x20>;
+                        xlnx,s4-axis-protocol = "GENERIC";
+                        xlnx,s8-axis-data-width = <0x20>;
+                        xlnx,edk-special = "microblaze";
+                        xlnx,use-dcache = <0x0>;
+                        xlnx,m-axi-dp-addr-width = <0x20>;
+                        xlnx,m-axi-ic-wuser-width = <0x1>;
+                        xlnx,i-axi = <0x0>;
+                        xlnx,icache-streams = <0x0>;
+                        xlnx,m-axi-dc-awuser-width = <0x5>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,use-stack-protection = <0x1>;
+                        xlnx,m6-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-dbg-clk = <0x1>;
+                        xlnx,m-axi-ip-data-width = <0x20>;
+                        d-cache-size = <0x2000>;
+                        xlnx,use-pcmp-instr = <0x1>;
+                        xlnx,area-optimized = <0x0>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,m1-axis-protocol = "GENERIC";
+                        xlnx,i-lmb = <0x1>;
+                        xlnx,lockstep-select = <0x0>;
+                        xlnx,dcache-data-width = <0x0>;
+                        xlnx,icache-force-tag-lutram = <0x0>;
+                        xlnx,m15-axis-protocol = "GENERIC";
+                        xlnx,use-branch-target-cache = <0x0>;
+                        xlnx,m-axi-ip-thread-id-width = <0x1>;
+                        xlnx,mmu-itlb-size = <0x2>;
+                        xlnx,number-of-pc-brk = <0x2>;
+                        xlnx,imprecise-exceptions = <0x0>;
+                        xlnx,m-axi-ic-buser-width = <0x1>;
+                        xlnx,m-axi-ic-addr-width = <0x20>;
+                        xlnx,s15-axis-protocol = "GENERIC";
+                        d-cache-highaddr = <0x3fffffff>;
+                        xlnx,m10-axis-protocol = "GENERIC";
+                        xlnx,optimization = <0x0>;
+                        xlnx,m-axi-ic-aruser-width = <0x5>;
+                        xlnx,d-lmb-mon = <0x0>;
+                        xlnx,s10-axis-protocol = "GENERIC";
+                        xlnx,m-axi-ic-ruser-width = <0x1>;
+                        xlnx,s5-axis-protocol = "GENERIC";
+                        xlnx,fault-tolerant = <0x1>;
+                        d-cache-line-size = <0x10>;
+                        xlnx,m-axi-dc-aruser-width = <0x5>;
+                        xlnx,mmu-privileged-instr = <0x0>;
+                        xlnx,m-axi-i-bus-exception = <0x0>;
+                        xlnx,reset-msr-eip = <0x0>;
+                        xlnx,endianness = <0x1>;
+                        xlnx,reset-msr-ice = <0x0>;
+                        xlnx,dp-axi-mon = <0x0>;
+                        xlnx,s10-axis-data-width = <0x20>;
+                        xlnx,s0-axis-protocol = "GENERIC";
+                        xlnx,s12-axis-data-width = <0x20>;
+                        xlnx,m7-axis-protocol = "GENERIC";
+                        xlnx,s14-axis-data-width = <0x20>;
+                        xlnx,m-axi-d-bus-exception = <0x1>;
+                        xlnx,reset-msr-bip = <0x1>;
+                        xlnx,debug-external-trace = <0x0>;
+                        xlnx,addr-size = <0x20>;
+                        xlnx,m-axi-ic-user-value = <0x1f>;
+                        xlnx,m1-axis-data-width = <0x20>;
+                        xlnx,debug-event-counters = <0x5>;
+                        xlnx,m3-axis-data-width = <0x20>;
+                        xlnx,fpu-exception = <0x0>;
+                        xlnx,m2-axis-protocol = "GENERIC";
+                        xlnx,m5-axis-data-width = <0x20>;
+                        xlnx,m7-axis-data-width = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        xlnx,debug-latency-counters = <0x1>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,m9-axis-data-width = <0x20>;
+                        xlnx,edge-is-positive = <0x1>;
+                        xlnx,use-icache = <0x0>;
+                        xlnx,async-wakeup = <0x3>;
+                        xlnx,m10-axis-data-width = <0x20>;
+                        xlnx,m12-axis-data-width = <0x20>;
+                        xlnx,use-ext-nm-brk = <0x0>;
+                        xlnx,m11-axis-protocol = "GENERIC";
+                        xlnx,m14-axis-data-width = <0x20>;
+                        xlnx,icache-always-used = <0x0>;
+                        xlnx,ic-axi-mon = <0x0>;
+                        xlnx,num-sync-ff-clk-irq = <0x1>;
+                        xlnx,freq = <0x1312d000>;
+                        xlnx,lockstep-master = <0x0>;
+                        xlnx,s11-axis-protocol = "GENERIC";
+                        xlnx,use-msr-instr = <0x1>;
+                        xlnx,s6-axis-protocol = "GENERIC";
+                        xlnx,iaddr-size = <0x20>;
+                        xlnx,interrupt-mon = <0x0>;
+                        xlnx,m-axi-dc-data-width = <0x20>;
+                        xlnx,dynamic-bus-sizing = <0x0>;
+                        xlnx,number-of-wr-addr-brk = <0x1>;
+                        xlnx,use-interrupt = <0x1>;
+                        xlnx,m-axi-ip-addr-width = <0x20>;
+                        xlnx,async-interrupt = <0x1>;
+                        xlnx,pc-width = <0x20>;
+                        xlnx,icache-victims = <0x0>;
+                        xlnx,reset-msr-ee = <0x0>;
+                        xlnx,s1-axis-protocol = "GENERIC";
+                        xlnx,m8-axis-protocol = "GENERIC";
+                        i-cache-baseaddr = <0x0>;
+                        xlnx,i-lmb-mon = <0x0>;
+                        xlnx,dcache-byte-size = <0x2000>;
+                        xlnx,m-axi-dp-thread-id-width = <0x1>;
+                        xlnx,data-size = <0x20>;
+                        xlnx,m-axi-dc-wuser-width = <0x1>;
+                        xlnx,fsl-exception = <0x0>;
+                        xlnx,m3-axis-protocol = "GENERIC";
+                        xlnx,s1-axis-data-width = <0x20>;
+                        xlnx,dcache-use-writeback = <0x0>;
+                        xlnx,div-zero-exception = <0x1>;
+                        xlnx,s3-axis-data-width = <0x20>;
+                        xlnx,base-vectors = <0xf0240000>;
+                        xlnx,icache-line-len = <0x4>;
+                        xlnx,s5-axis-data-width = <0x20>;
+                        xlnx,s7-axis-data-width = <0x20>;
+                        xlnx,allow-dcache-wr = <0x1>;
+                        xlnx,s9-axis-data-width = <0x20>;
+                        xlnx,use-barrel = <0x1>;
+                        xlnx,g-use-exceptions = <0x1>;
+                        xlnx,dcache-line-len = <0x4>;
+                        xlnx,m12-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-clk = <0x2>;
+                        i-cache-size = <0x2000>;
+                        xlnx,instance = "design_1_microblaze_0_0";
+                        xlnx,reset-msr-ie = <0x0>;
+                        xlnx,s12-axis-protocol = "GENERIC";
+                        xlnx,dcache-addr-tag = <0x0>;
+                        xlnx,m-axi-ic-thread-id-width = <0x1>;
+                        xlnx,number-of-rd-addr-brk = <0x1>;
+                        xlnx,m-axi-dc-buser-width = <0x1>;
+                        xlnx,s7-axis-protocol = "GENERIC";
+                        xlnx,lockstep-slave = <0x0>;
+                        xlnx,debug-profile-size = <0x0>;
+                        xlnx,s2-axis-protocol = "GENERIC";
+                        xlnx,m9-axis-protocol = "GENERIC";
+                        xlnx,debug-counter-width = <0x20>;
+                        xlnx,icache-data-width = <0x0>;
+                        xlnx,m-axi-dc-ruser-width = <0x1>;
+                        xlnx,reset-msr-dce = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc";
+                        xlnx,ip-axi-mon = <0x0>;
+                        xlnx,m-axi-dp-data-width = <0x20>;
+                        xlnx,m4-axis-protocol = "GENERIC";
+                        xlnx,dcache-always-used = <0x0>;
+                        xlnx,ill-opcode-exception = <0x1>;
+                        xlnx,trace = <0x1>;
+                        xlnx,pvr = <0x2>;
+                        xlnx,debug-trace-size = <0x2000>;
+                        i-cache-line-size = <0x10>;
+                        xlnx,m13-axis-protocol = "GENERIC";
+                        xlnx,s11-axis-data-width = <0x20>;
+                        xlnx,m-axi-dc-addr-width = <0x20>;
+                        xlnx,s13-axis-data-width = <0x20>;
+                        xlnx,ecc-use-ce-exception = <0x0>;
+                        xlnx,opcode-0x0-illegal = <0x1>;
+                        xlnx,pvr-user2 = <0x0>;
+                        xlnx,s15-axis-data-width = <0x20>;
+                        xlnx,s13-axis-protocol = "GENERIC";
+                        xlnx,m0-axis-data-width = <0x20>;
+                        i-cache-highaddr = <0x3fffffff>;
+                        xlnx,s8-axis-protocol = "GENERIC";
+                        xlnx,m2-axis-data-width = <0x20>;
+                        xlnx,num-sync-ff-clk-debug = <0x2>;
+                        xlnx,allow-icache-wr = <0x1>;
+                        xlnx,m4-axis-data-width = <0x20>;
+                        xlnx,g-template-list = <0x0>;
+                        xlnx,m6-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-data-width = <0x20>;
+                        xlnx,m8-axis-data-width = <0x20>;
+                        xlnx,use-hw-mul = <0x2>;
+                        xlnx,use-fpu = <0x0>;
+                        xlnx,s3-axis-protocol = "GENERIC";
+                        xlnx,use-non-secure = <0x0>;
+                        d-cache-baseaddr = <0x0>;
+                        xlnx,m11-axis-data-width = <0x20>;
+                        xlnx,m13-axis-data-width = <0x20>;
+                        xlnx,instr-size = <0x20>;
+                        xlnx,m15-axis-data-width = <0x20>;
+                        xlnx,mmu-dtlb-size = <0x4>;
+                        xlnx,fsl-links = <0x0>;
+                        xlnx,m5-axis-protocol = "GENERIC";
+                        xlnx,dcache-victims = <0x0>;
+                        xlnx,m-axi-dc-user-value = <0x1f>;
+                        xlnx,unaligned-exceptions = <0x1>;
+                        phandle = <0xa1>;
+                };
+        };
+
+        cpus_microblaze_1: cpus_microblaze@1 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0x0 &axi_noc_0_ddr_memory 0x0 0x80000000>,
+                 <0xff310000 &ipi_psm 0xff310000 0x10000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0xffe00000 &psv_r5_0_atcm_global 0xffe00000 0x40000>,
+                 <0xffe90000 &psv_r5_1_atcm_global 0xffe90000 0x10000>,
+                 <0xffeb0000 &psv_r5_1_btcm_global 0xffeb0000 0x10000>,
+                 <0xffc00000 &versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr 0xffc00000 0x20000>,
+                 <0xffc20000 &versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr 0xffc20000 0x20000>,
+                 <0xffc80000 &versal_cips_0_pspmc_0_psv_psm_iomodule_0 0xffc80000 0x8000>,
+                 <0xffcc0000 &versal_cips_0_pspmc_0_psv_psm_tmr_manager_0 0xffcc0000 0x10000>,
+                 <0xffcd0000 &versal_cips_0_pspmc_0_psv_psm_tmr_inject_0 0xffcd0000 0x10000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa2>;
+
+                psv_psm_0: cpu@0 {
+                        compatible = "psm-microblaze";
+                        device_type = "cpu";
+                        reg = <0x1>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        xlnx,d-axi = <0x1>;
+                        xlnx,addr-tag-bits = <0x0>;
+                        xlnx,m-axi-dc-thread-id-width = <0x1>;
+                        xlnx,m0-axis-protocol = "GENERIC";
+                        xlnx,dcache-force-tag-lutram = <0x0>;
+                        xlnx,interrupt-is-edge = <0x0>;
+                        xlnx,use-mmu = <0x0>;
+                        xlnx,m-axi-dp-exclusive-access = <0x0>;
+                        xlnx,use-reorder-instr = <0x1>;
+                        xlnx,m14-axis-protocol = "GENERIC";
+                        xlnx,use-div = <0x1>;
+                        xlnx,dc-axi-mon = <0x0>;
+                        xlnx,m-axi-ic-user-signals = <0x0>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,s14-axis-protocol = "GENERIC";
+                        xlnx,mmu-zones = <0x10>;
+                        xlnx,enable-discrete-ports = <0x0>;
+                        xlnx,d-lmb = <0x1>;
+                        xlnx,m-axi-dc-exclusive-access = <0x0>;
+                        xlnx,debug-interface = <0x0>;
+                        xlnx,s9-axis-protocol = "GENERIC";
+                        xlnx,sco = <0x0>;
+                        xlnx,use-ext-brk = <0x0>;
+                        xlnx,debug-enabled = <0x1>;
+                        xlnx,daddr-size = <0x20>;
+                        xlnx,s0-axis-data-width = <0x20>;
+                        xlnx,use-extended-fsl-instr = <0x0>;
+                        xlnx,m-axi-dc-user-signals = <0x0>;
+                        xlnx,reset-msr = <0x0>;
+                        xlnx,branch-target-cache-size = <0x0>;
+                        xlnx,s2-axis-data-width = <0x20>;
+                        bus-handle = <0x1>;
+                        xlnx,cache-byte-size = <0x2000>;
+                        xlnx,mmu-tlb-access = <0x3>;
+                        xlnx,s4-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-awuser-width = <0x5>;
+                        xlnx,s6-axis-data-width = <0x20>;
+                        xlnx,s4-axis-protocol = "GENERIC";
+                        xlnx,s8-axis-data-width = <0x20>;
+                        xlnx,edk-special = "microblaze";
+                        xlnx,use-dcache = <0x0>;
+                        xlnx,m-axi-dp-addr-width = <0x20>;
+                        xlnx,m-axi-ic-wuser-width = <0x1>;
+                        xlnx,i-axi = <0x0>;
+                        xlnx,icache-streams = <0x0>;
+                        xlnx,m-axi-dc-awuser-width = <0x5>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,use-stack-protection = <0x1>;
+                        xlnx,m6-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-dbg-clk = <0x1>;
+                        xlnx,m-axi-ip-data-width = <0x20>;
+                        d-cache-size = <0x2000>;
+                        xlnx,use-pcmp-instr = <0x1>;
+                        xlnx,area-optimized = <0x0>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,m1-axis-protocol = "GENERIC";
+                        xlnx,i-lmb = <0x1>;
+                        xlnx,lockstep-select = <0x0>;
+                        xlnx,dcache-data-width = <0x0>;
+                        xlnx,icache-force-tag-lutram = <0x0>;
+                        xlnx,m15-axis-protocol = "GENERIC";
+                        xlnx,use-branch-target-cache = <0x0>;
+                        xlnx,m-axi-ip-thread-id-width = <0x1>;
+                        xlnx,mmu-itlb-size = <0x2>;
+                        xlnx,number-of-pc-brk = <0x2>;
+                        xlnx,imprecise-exceptions = <0x0>;
+                        xlnx,m-axi-ic-buser-width = <0x1>;
+                        xlnx,m-axi-ic-addr-width = <0x20>;
+                        xlnx,s15-axis-protocol = "GENERIC";
+                        d-cache-highaddr = <0x3fffffff>;
+                        xlnx,m10-axis-protocol = "GENERIC";
+                        xlnx,optimization = <0x0>;
+                        xlnx,m-axi-ic-aruser-width = <0x5>;
+                        xlnx,d-lmb-mon = <0x0>;
+                        xlnx,s10-axis-protocol = "GENERIC";
+                        xlnx,m-axi-ic-ruser-width = <0x1>;
+                        xlnx,s5-axis-protocol = "GENERIC";
+                        xlnx,fault-tolerant = <0x1>;
+                        d-cache-line-size = <0x10>;
+                        xlnx,m-axi-dc-aruser-width = <0x5>;
+                        xlnx,mmu-privileged-instr = <0x0>;
+                        xlnx,m-axi-i-bus-exception = <0x0>;
+                        xlnx,reset-msr-eip = <0x0>;
+                        xlnx,endianness = <0x1>;
+                        xlnx,reset-msr-ice = <0x0>;
+                        xlnx,dp-axi-mon = <0x0>;
+                        xlnx,s10-axis-data-width = <0x20>;
+                        xlnx,s0-axis-protocol = "GENERIC";
+                        xlnx,s12-axis-data-width = <0x20>;
+                        xlnx,m7-axis-protocol = "GENERIC";
+                        xlnx,s14-axis-data-width = <0x20>;
+                        xlnx,m-axi-d-bus-exception = <0x1>;
+                        xlnx,reset-msr-bip = <0x1>;
+                        xlnx,debug-external-trace = <0x0>;
+                        xlnx,addr-size = <0x20>;
+                        xlnx,m-axi-ic-user-value = <0x1f>;
+                        xlnx,m1-axis-data-width = <0x20>;
+                        xlnx,debug-event-counters = <0x5>;
+                        xlnx,m3-axis-data-width = <0x20>;
+                        xlnx,fpu-exception = <0x0>;
+                        xlnx,m2-axis-protocol = "GENERIC";
+                        xlnx,m5-axis-data-width = <0x20>;
+                        xlnx,m7-axis-data-width = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        xlnx,debug-latency-counters = <0x1>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,m9-axis-data-width = <0x20>;
+                        xlnx,edge-is-positive = <0x1>;
+                        xlnx,use-icache = <0x0>;
+                        xlnx,async-wakeup = <0x3>;
+                        xlnx,m10-axis-data-width = <0x20>;
+                        xlnx,m12-axis-data-width = <0x20>;
+                        xlnx,use-ext-nm-brk = <0x0>;
+                        xlnx,m11-axis-protocol = "GENERIC";
+                        xlnx,m14-axis-data-width = <0x20>;
+                        xlnx,icache-always-used = <0x0>;
+                        xlnx,ic-axi-mon = <0x0>;
+                        xlnx,num-sync-ff-clk-irq = <0x1>;
+                        xlnx,freq = <0x5f5e100>;
+                        xlnx,lockstep-master = <0x0>;
+                        xlnx,s11-axis-protocol = "GENERIC";
+                        xlnx,use-msr-instr = <0x1>;
+                        xlnx,s6-axis-protocol = "GENERIC";
+                        xlnx,iaddr-size = <0x20>;
+                        xlnx,interrupt-mon = <0x0>;
+                        xlnx,m-axi-dc-data-width = <0x20>;
+                        xlnx,dynamic-bus-sizing = <0x0>;
+                        xlnx,number-of-wr-addr-brk = <0x1>;
+                        xlnx,use-interrupt = <0x1>;
+                        xlnx,m-axi-ip-addr-width = <0x20>;
+                        xlnx,async-interrupt = <0x1>;
+                        xlnx,pc-width = <0x20>;
+                        xlnx,icache-victims = <0x0>;
+                        xlnx,reset-msr-ee = <0x0>;
+                        xlnx,s1-axis-protocol = "GENERIC";
+                        xlnx,m8-axis-protocol = "GENERIC";
+                        i-cache-baseaddr = <0x0>;
+                        xlnx,i-lmb-mon = <0x0>;
+                        xlnx,dcache-byte-size = <0x2000>;
+                        xlnx,m-axi-dp-thread-id-width = <0x1>;
+                        xlnx,data-size = <0x20>;
+                        xlnx,m-axi-dc-wuser-width = <0x1>;
+                        xlnx,fsl-exception = <0x0>;
+                        xlnx,m3-axis-protocol = "GENERIC";
+                        xlnx,s1-axis-data-width = <0x20>;
+                        xlnx,dcache-use-writeback = <0x0>;
+                        xlnx,div-zero-exception = <0x1>;
+                        xlnx,s3-axis-data-width = <0x20>;
+                        xlnx,base-vectors = <0xffc00000>;
+                        xlnx,icache-line-len = <0x4>;
+                        xlnx,s5-axis-data-width = <0x20>;
+                        xlnx,s7-axis-data-width = <0x20>;
+                        xlnx,allow-dcache-wr = <0x1>;
+                        xlnx,s9-axis-data-width = <0x20>;
+                        xlnx,use-barrel = <0x1>;
+                        xlnx,g-use-exceptions = <0x1>;
+                        xlnx,dcache-line-len = <0x4>;
+                        xlnx,m12-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-clk = <0x2>;
+                        i-cache-size = <0x2000>;
+                        xlnx,instance = "design_1_microblaze_0_0";
+                        xlnx,reset-msr-ie = <0x0>;
+                        xlnx,s12-axis-protocol = "GENERIC";
+                        xlnx,dcache-addr-tag = <0x0>;
+                        xlnx,m-axi-ic-thread-id-width = <0x1>;
+                        xlnx,number-of-rd-addr-brk = <0x1>;
+                        xlnx,m-axi-dc-buser-width = <0x1>;
+                        xlnx,s7-axis-protocol = "GENERIC";
+                        xlnx,lockstep-slave = <0x0>;
+                        xlnx,debug-profile-size = <0x0>;
+                        xlnx,s2-axis-protocol = "GENERIC";
+                        xlnx,m9-axis-protocol = "GENERIC";
+                        xlnx,debug-counter-width = <0x20>;
+                        xlnx,icache-data-width = <0x0>;
+                        xlnx,m-axi-dc-ruser-width = <0x1>;
+                        xlnx,reset-msr-dce = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_psm";
+                        xlnx,ip-axi-mon = <0x0>;
+                        xlnx,m-axi-dp-data-width = <0x20>;
+                        xlnx,m4-axis-protocol = "GENERIC";
+                        xlnx,dcache-always-used = <0x0>;
+                        xlnx,ill-opcode-exception = <0x1>;
+                        xlnx,trace = <0x1>;
+                        xlnx,pvr = <0x2>;
+                        xlnx,debug-trace-size = <0x2000>;
+                        i-cache-line-size = <0x10>;
+                        xlnx,m13-axis-protocol = "GENERIC";
+                        xlnx,s11-axis-data-width = <0x20>;
+                        xlnx,m-axi-dc-addr-width = <0x20>;
+                        xlnx,s13-axis-data-width = <0x20>;
+                        xlnx,ecc-use-ce-exception = <0x0>;
+                        xlnx,opcode-0x0-illegal = <0x1>;
+                        xlnx,pvr-user2 = <0x0>;
+                        xlnx,s15-axis-data-width = <0x20>;
+                        xlnx,s13-axis-protocol = "GENERIC";
+                        xlnx,m0-axis-data-width = <0x20>;
+                        i-cache-highaddr = <0x3fffffff>;
+                        xlnx,s8-axis-protocol = "GENERIC";
+                        xlnx,m2-axis-data-width = <0x20>;
+                        xlnx,num-sync-ff-clk-debug = <0x2>;
+                        xlnx,allow-icache-wr = <0x1>;
+                        xlnx,m4-axis-data-width = <0x20>;
+                        xlnx,g-template-list = <0x0>;
+                        xlnx,m6-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-data-width = <0x20>;
+                        xlnx,m8-axis-data-width = <0x20>;
+                        xlnx,use-hw-mul = <0x2>;
+                        xlnx,use-fpu = <0x0>;
+                        xlnx,s3-axis-protocol = "GENERIC";
+                        xlnx,use-non-secure = <0x0>;
+                        d-cache-baseaddr = <0x0>;
+                        xlnx,m11-axis-data-width = <0x20>;
+                        xlnx,m13-axis-data-width = <0x20>;
+                        xlnx,instr-size = <0x20>;
+                        xlnx,m15-axis-data-width = <0x20>;
+                        xlnx,mmu-dtlb-size = <0x4>;
+                        xlnx,fsl-links = <0x0>;
+                        xlnx,m5-axis-protocol = "GENERIC";
+                        xlnx,dcache-victims = <0x0>;
+                        xlnx,m-axi-dc-user-value = <0x1f>;
+                        xlnx,unaligned-exceptions = <0x1>;
+                        phandle = <0xa3>;
+                };
+        };
+
+        cpus_r5_0: cpus-r5@0 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0xf9000000 &amba_rpu 0xf9000000 0x3000>,
+                 <0x40000 &axi_noc_0_ddr_memory 0x40000 0x7ffc0000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0800000 &coresight 0xf0800000 0x10000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5c0000 &versal_cips_0_pspmc_0_psv_apu_0 0xfd5c0000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9a0000 &versal_cips_0_pspmc_0_psv_rpu_0 0xff9a0000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_0_atcm 0x0 0x10000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_tcm_ram_0 0x0 0x40000>,
+                 <0x20000 &versal_cips_0_pspmc_0_psv_r5_0_btcm 0x20000 0x10000>,
+                 <0xf9000000 &gic_r5 0xf9000000 0x3000>,
+                 <0xffe40000 &versal_cips_0_pspmc_0_psv_r5_0_instruction_cache 0xffe40000 0x10000>,
+                 <0xffe50000 &versal_cips_0_pspmc_0_psv_r5_0_data_cache 0xffe50000 0x10000>,
+                 <0xffec0000 &versal_cips_0_pspmc_0_psv_r5_1_instruction_cache 0xffec0000 0x10000>,
+                 <0xffed0000 &versal_cips_0_pspmc_0_psv_r5_1_data_cache 0xffed0000 0x10000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa4>;
+
+                psv_cortexr5_0: cpu@0 {
+                        compatible = "arm,cortex-r5";
+                        device_type = "cpu";
+                        reg = <0x0>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        power-domains = <&versal_firmware 0x18110005>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,ip-name = "psv_cortexr5";
+                        access-val = <0xff>;
+                        bus-handle = <0x1>;
+                        xlnx,cpu-clk-freq-hz = <0x23c32ea3>;
+                        cpu-frequency = <0x23c32ea3>;
+                        phandle = <0xa5>;
+                };
+        };
+
+        cpus_r5_1: cpus-r5@1 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0xf9000000 &amba_rpu 0xf9000000 0x3000>,
+                 <0x40000 &axi_noc_0_ddr_memory 0x40000 0x7ffc0000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0800000 &coresight 0xf0800000 0x10000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5c0000 &versal_cips_0_pspmc_0_psv_apu_0 0xfd5c0000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9a0000 &versal_cips_0_pspmc_0_psv_rpu_0 0xff9a0000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_tcm_ram_0 0x0 0x40000>,
+                 <0xf9000000 &gic_r5 0xf9000000 0x3000>,
+                 <0xffe40000 &versal_cips_0_pspmc_0_psv_r5_0_instruction_cache 0xffe40000 0x10000>,
+                 <0xffe50000 &versal_cips_0_pspmc_0_psv_r5_0_data_cache 0xffe50000 0x10000>,
+                 <0xffec0000 &versal_cips_0_pspmc_0_psv_r5_1_instruction_cache 0xffec0000 0x10000>,
+                 <0xffed0000 &versal_cips_0_pspmc_0_psv_r5_1_data_cache 0xffed0000 0x10000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_1_atcm 0x0 0x10000>,
+                 <0x20000 &versal_cips_0_pspmc_0_psv_r5_1_btcm 0x20000 0x10000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa6>;
+
+                psv_cortexr5_1: cpu@1 {
+                        compatible = "arm,cortex-r5";
+                        device_type = "cpu";
+                        reg = <0x1>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        power-domains = <&versal_firmware 0x18110006>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,ip-name = "psv_cortexr5";
+                        access-val = <0xff>;
+                        bus-handle = <0x1>;
+                        xlnx,cpu-clk-freq-hz = <0x23c32ea3>;
+                        cpu-frequency = <0x23c32ea3>;
+                        phandle = <0xa7>;
+                };
+        };
+
+        cpu_opp_table: opp-table-cpu {
+                compatible = "operating-points-v2";
+                opp-shared;
+                phandle = <0x73>;
+
+                opp-1400000000 {
+                        opp-hz = <0x0 0x53724e00>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-700000000 {
+                        opp-hz = <0x0 0x29b92700>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-466666666 {
+                        opp-hz = <0x0 0x1bd0c4aa>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-350000000 {
+                        opp-hz = <0x0 0x14dc9380>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+        };
+
+        dcc: dcc {
+                compatible = "arm,dcc";
+                status = "disabled";
+                bootph-all;
+                phandle = <0xa8>;
+        };
+
+        fpga: fpga-region {
+                compatible = "fpga-region";
+                fpga-mgr = <&versal_fpga>;
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0xa9>;
+        };
+
+        psci: psci {
+                compatible = "arm,psci-0.2";
+                method = "smc";
+                phandle = <0xaa>;
+        };
+
+        pmu {
+                compatible = "arm,armv8-pmuv3";
+                interrupt-parent = <&imux>;
+                interrupts = <0x1 0x7 0x304>;
+        };
+
+        timer: timer {
+                compatible = "arm,armv8-timer";
+                interrupt-parent = <&imux>;
+                interrupts = <0x1 0xd 0x4 0x1 0xe 0x4 0x1 0xb 0x4 0x1 0xa 0x4>;
+                phandle = <0xab>;
+        };
+
+        versal_fpga: versal-fpga {
+                compatible = "xlnx,versal-fpga";
+                phandle = <0x8f>;
+        };
+
+        sensor0: versal-thermal-sensor {
+                compatible = "xlnx,versal-thermal";
+                #thermal-sensor-cells = <0x0>;
+                io-channels = <0x37>;
+                io-channel-names = "sysmon-temp-channel";
+                phandle = <0x91>;
+        };
+
+        thermal-zones {
+
+                versal_thermal: versal-thermal {
+                        polling-delay-passive = <0xfa>;
+                        polling-delay = <0x3e8>;
+                        thermal-sensors = <0x91>;
+                        phandle = <0xac>;
+
+                        trips {
+
+                                temp_alert: temp-alert {
+                                        temperature = <0x11170>;
+                                        hysteresis = <0x0>;
+                                        type = "passive";
+                                        phandle = <0xad>;
+                                };
+
+                                ot_crit: ot-crit {
+                                        temperature = <0x1e848>;
+                                        hysteresis = <0x0>;
+                                        type = "critical";
+                                        phandle = <0xae>;
+                                };
+                        };
+                };
+        };
+
+        amba_apu: apu-bus {
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&gic_a72>;
+                bootph-all;
+                phandle = <0x2>;
+
+                gic_a72: interrupt-controller@f9000000 {
+                        compatible = "arm,gic-v3";
+                        #interrupt-cells = <0x3>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        reg = <0x0 0xf9000000 0x0 0x80000 0x0 0xf9080000 0x0 0x80000>;
+                        interrupt-controller;
+                        interrupt-parent = <&gic_a72>;
+                        interrupts = <0x1 0x9 0x4>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,apu-gic-its-ctl = <0xf9020000>;
+                        xlnx,ip-name = "psv_acpu_gic";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_acpu_gic";
+                        phandle = <0x40>;
+
+                        gic_its: msi-controller@f9020000 {
+                                compatible = "arm,gic-v3-its";
+                                status = "okay";
+                                msi-controller;
+                                #msi-cells = <0x1>;
+                                reg = <0x0 0xf9020000 0x0 0x20000>;
+                                phandle = <0x4>;
+                        };
+                };
+        };
+
+        amba_rpu: rpu-bus {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&gic_r5>;
+                bootph-all;
+                phandle = <0x84>;
+
+                gic_r5: interrupt-controller@f9000000 {
+                        compatible = "arm,pl390";
+                        #interrupt-cells = <0x3>;
+                        interrupt-controller;
+                        status = "okay";
+                        reg = <0x0 0xf9000000 0x0 0x1000 0x0 0xf9001000 0x0 0x1000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_rcpu_gic";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_rcpu_gic";
+                        phandle = <0x88>;
+                };
+        };
+
+        amba: axi {
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&imux>;
+                bootph-all;
+                phandle = <0x1>;
+
+                imux: interrupt-multiplex {
+                        compatible = "interrupt-multiplex";
+                        #address-cells = <0x0>;
+                        #interrupt-cells = <0x3>;
+                        interrupt-controller;
+                        interrupt-parent = <&gic_a72>,
+                         <&gic_r5>;
+                        interrupt-map-mask = <0x0 0xffff 0x0>;
+                        interrupt-map = <0x0 0x14 0x0 &gic_a72 0x0 0x14 0x1>,
+                         <0x0 0x15 0x0 &gic_a72 0x0 0x15 0x1>,
+                         <0x0 0x6a 0x0 &gic_a72 0x0 0x6a 0x4>,
+                         <0x0 0x3c 0x0 &gic_a72 0x0 0x3c 0x4>,
+                         <0x0 0x3d 0x0 &gic_a72 0x0 0x3d 0x4>,
+                         <0x0 0x3e 0x0 &gic_a72 0x0 0x3e 0x4>,
+                         <0x0 0x3f 0x0 &gic_a72 0x0 0x3f 0x4>,
+                         <0x0 0x40 0x0 &gic_a72 0x0 0x40 0x4>,
+                         <0x0 0x41 0x0 &gic_a72 0x0 0x41 0x4>,
+                         <0x0 0x42 0x0 &gic_a72 0x0 0x42 0x4>,
+                         <0x0 0x43 0x0 &gic_a72 0x0 0x43 0x4>,
+                         <0x0 0x38 0x0 &gic_a72 0x0 0x38 0x4>,
+                         <0x0 0x3a 0x0 &gic_a72 0x0 0x3a 0x4>,
+                         <0x0 0xd 0x0 &gic_a72 0x0 0xd 0x4>,
+                         <0x0 0x7a 0x0 &gic_a72 0x0 0x7a 0x4>,
+                         <0x0 0xe 0x0 &gic_a72 0x0 0xe 0x4>,
+                         <0x0 0xf 0x0 &gic_a72 0x0 0xf 0x4>,
+                         <0x0 0x8e 0x0 &gic_a72 0x0 0x8e 0x4>,
+                         <0x0 0x8f 0x0 &gic_a72 0x0 0x8f 0x4>,
+                         <0x0 0x7e 0x0 &gic_a72 0x0 0x7e 0x4>,
+                         <0x0 0x80 0x0 &gic_a72 0x0 0x80 0x4>,
+                         <0x0 0x12 0x0 &gic_a72 0x0 0x12 0x4>,
+                         <0x0 0x13 0x0 &gic_a72 0x0 0x13 0x4>,
+                         <0x0 0x6b 0x0 &gic_a72 0x0 0x6b 0x4>,
+                         <0x0 0x7c 0x0 &gic_a72 0x0 0x7c 0x4>,
+                         <0x0 0x7d 0x0 &gic_a72 0x0 0x7d 0x4>,
+                         <0x0 0x10 0x0 &gic_a72 0x0 0x10 0x4>,
+                         <0x0 0x11 0x0 &gic_a72 0x0 0x11 0x4>,
+                         <0x0 0x16 0x0 &gic_a72 0x0 0x16 0x4>,
+                         <0x0 0x1a 0x0 &gic_a72 0x0 0x1a 0x4>,
+                         <0x0 0x4a 0x0 &gic_a72 0x0 0x4a 0x4>,
+                         <0x0 0x48 0x0 &gic_a72 0x0 0x48 0x4>,
+                         <0x0 0x1e 0x0 &gic_a72 0x0 0x1e 0x4>,
+                         <0x0 0x1f 0x0 &gic_a72 0x0 0x1f 0x4>,
+                         <0x0 0x83 0x0 &gic_a72 0x0 0x83 0x4>,
+                         <0x0 0x84 0x0 &gic_a72 0x0 0x84 0x4>,
+                         <0x0 0x14 0x0 &gic_r5 0x0 0x14 0x1>,
+                         <0x0 0x15 0x0 &gic_r5 0x0 0x15 0x1>,
+                         <0x0 0x6a 0x0 &gic_r5 0x0 0x6a 0x4>,
+                         <0x0 0x3c 0x0 &gic_r5 0x0 0x3c 0x4>,
+                         <0x0 0x3d 0x0 &gic_r5 0x0 0x3d 0x4>,
+                         <0x0 0x3e 0x0 &gic_r5 0x0 0x3e 0x4>,
+                         <0x0 0x3f 0x0 &gic_r5 0x0 0x3f 0x4>,
+                         <0x0 0x40 0x0 &gic_r5 0x0 0x40 0x4>,
+                         <0x0 0x41 0x0 &gic_r5 0x0 0x41 0x4>,
+                         <0x0 0x42 0x0 &gic_r5 0x0 0x42 0x4>,
+                         <0x0 0x43 0x0 &gic_r5 0x0 0x43 0x4>,
+                         <0x0 0x38 0x0 &gic_r5 0x0 0x38 0x4>,
+                         <0x0 0x3a 0x0 &gic_r5 0x0 0x3a 0x4>,
+                         <0x0 0xd 0x0 &gic_r5 0x0 0xd 0x4>,
+                         <0x0 0x7a 0x0 &gic_r5 0x0 0x7a 0x4>,
+                         <0x0 0xe 0x0 &gic_r5 0x0 0xe 0x4>,
+                         <0x0 0xf 0x0 &gic_r5 0x0 0xf 0x4>,
+                         <0x0 0x8e 0x0 &gic_r5 0x0 0x8e 0x4>,
+                         <0x0 0x8f 0x0 &gic_r5 0x0 0x8f 0x4>,
+                         <0x0 0x7e 0x0 &gic_r5 0x0 0x7e 0x4>,
+                         <0x0 0x80 0x0 &gic_r5 0x0 0x80 0x4>,
+                         <0x0 0x12 0x0 &gic_r5 0x0 0x12 0x4>,
+                         <0x0 0x13 0x0 &gic_r5 0x0 0x13 0x4>,
+                         <0x0 0x6b 0x0 &gic_r5 0x0 0x6b 0x4>,
+                         <0x0 0x7c 0x0 &gic_r5 0x0 0x7c 0x4>,
+                         <0x0 0x7d 0x0 &gic_r5 0x0 0x7d 0x4>,
+                         <0x0 0x10 0x0 &gic_r5 0x0 0x10 0x4>,
+                         <0x0 0x11 0x0 &gic_r5 0x0 0x11 0x4>,
+                         <0x0 0x16 0x0 &gic_r5 0x0 0x16 0x4>,
+                         <0x0 0x1a 0x0 &gic_r5 0x0 0x1a 0x4>,
+                         <0x0 0x4a 0x0 &gic_r5 0x0 0x4a 0x4>,
+                         <0x0 0x48 0x0 &gic_r5 0x0 0x48 0x4>,
+                         <0x0 0x1e 0x0 &gic_r5 0x0 0x1e 0x4>,
+                         <0x0 0x1f 0x0 &gic_r5 0x0 0x1f 0x4>,
+                         <0x0 0x83 0x0 &gic_r5 0x0 0x83 0x4>,
+                         <0x0 0x84 0x0 &gic_r5 0x0 0x84 0x4>;
+                        phandle = <0x90>;
+                };
+
+                can0: can@ff060000 {
+                        compatible = "xlnx,canfd-2.0";
+                        status = "disabled";
+                        reg = <0x0 0xff060000 0x0 0x6000>;
+                        interrupts = <0x0 0x14 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "can_clk", "s_axi_aclk";
+                        rx-fifo-depth = <0x40>;
+                        tx-mailbox-count = <0x20>;
+                        clocks = <&can0_clk>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401f>;
+                        phandle = <0xaf>;
+                };
+
+                can1: can@ff070000 {
+                        compatible = "xlnx,canfd-2.0";
+                        status = "disabled";
+                        reg = <0x0 0xff070000 0x0 0x6000>;
+                        interrupts = <0x0 0x15 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "can_clk", "s_axi_aclk";
+                        rx-fifo-depth = <0x40>;
+                        tx-mailbox-count = <0x20>;
+                        clocks = <&can1_clk>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224020>;
+                        phandle = <0xb0>;
+                };
+
+                cci: cci@fd000000 {
+                        compatible = "arm,cci-500";
+                        status = "okay";
+                        reg = <0x0 0xfd000000 0x0 0x10000>;
+                        ranges = <0x0 0x0 0xfd000000 0xa0000>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x1>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_fpd_maincci";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_maincci_0";
+                        phandle = <0x42>;
+
+                        cci_pmu: pmu@10000 {
+                                compatible = "arm,cci-500-pmu,r0";
+                                reg = <0x10000 0x90000>;
+                                interrupt-parent = <&imux>;
+                                interrupts = <0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4>;
+                                phandle = <0xb1>;
+                        };
+                };
+
+                lpd_dma_chan0: dma-controller@ffa80000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffa80000 0x0 0x1000>;
+                        interrupts = <0x0 0x3c 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224035>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_0";
+                        phandle = <0x61>;
+                };
+
+                lpd_dma_chan1: dma-controller@ffa90000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffa90000 0x0 0x1000>;
+                        interrupts = <0x0 0x3d 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224036>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_1";
+                        phandle = <0x62>;
+                };
+
+                lpd_dma_chan2: dma-controller@ffaa0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffaa0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3e 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224037>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_2";
+                        phandle = <0x63>;
+                };
+
+                lpd_dma_chan3: dma-controller@ffab0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffab0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3f 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224038>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_3";
+                        phandle = <0x64>;
+                };
+
+                lpd_dma_chan4: dma-controller@ffac0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffac0000 0x0 0x1000>;
+                        interrupts = <0x0 0x40 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224039>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_4";
+                        phandle = <0x65>;
+                };
+
+                lpd_dma_chan5: dma-controller@ffad0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffad0000 0x0 0x1000>;
+                        interrupts = <0x0 0x41 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403a>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_5";
+                        phandle = <0x66>;
+                };
+
+                lpd_dma_chan6: dma-controller@ffae0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffae0000 0x0 0x1000>;
+                        interrupts = <0x0 0x42 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403b>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_6";
+                        phandle = <0x67>;
+                };
+
+                lpd_dma_chan7: dma-controller@ffaf0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffaf0000 0x0 0x1000>;
+                        interrupts = <0x0 0x43 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403c>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_7";
+                        phandle = <0x68>;
+                };
+
+                gem0: ethernet@ff0c0000 {
+                        compatible = "xlnx,versal-gem", "cdns,gem";
+                        status = "okay";
+                        reg = <0x0 0xff0c0000 0x0 0x1000>;
+                        interrupts = <0x0 0x38 0x4 0x0 0x38 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x52>,
+                         <&versal_clk 0x58>,
+                         <&versal_clk 0x31>,
+                         <&versal_clk 0x30>,
+                         <&versal_clk 0x2b>;
+                        power-domains = <&versal_firmware 0x18224019>;
+                        xlnx,has-mdio = <0x1>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,gem-board-interface = "custom";
+                        phy-mode = "rgmii-id";
+                        xlnx,enet-slcr-1000mbps-div0 = <0x2>;
+                        xlnx,enet-slcr-10mbps-div0 = <0x64>;
+                        xlnx,rable = <0x0>;
+                        xlnx,enet-tsu-clk-freq-hz = <0xee6a8ba>;
+                        xlnx,ip-name = "psv_ethernet";
+                        xlnx,eth-mode = <0x1>;
+                        xlnx,enet-clk-freq-hz = <0x773545d>;
+                        xlnx,enet-slcr-100mbps-div0 = <0xa>;
+                        local-mac-address = [00 0A 23 00 00 00];
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ethernet_0";
+                        phy-handle = <0x94>;
+                        phandle = <0x54>;
+
+                        mdio: mdio {
+                                #address-cells = <0x1>;
+                                #size-cells = <0x0>;
+                                phandle = <0xb2>;
+
+                                phy1: ethernet-phy@1 {
+                                        #phy-cells = <0x1>;
+                                        compatible = "ethernet-phy-id2000.a231";
+                                        reg = <0x1>;
+                                        ti,rx-internal-delay = <0xb>;
+                                        ti,tx-internal-delay = <0xa>;
+                                        ti,fifo-depth = <0x1>;
+                                        ti,dp83867-rxctrl-strap-quirk;
+                                        reset-assert-us = <0x64>;
+                                        reset-deassert-us = <0x118>;
+                                        reset-gpios = <&gpio1 0x30 0x1>;
+                                        phandle = <0x94>;
+                                };
+
+                                phy2: ethernet-phy@2 {
+                                        #phy-cells = <0x1>;
+                                        compatible = "ethernet-phy-id2000.a231";
+                                        reg = <0x2>;
+                                        ti,rx-internal-delay = <0xb>;
+                                        ti,tx-internal-delay = <0xa>;
+                                        ti,fifo-depth = <0x1>;
+                                        ti,dp83867-rxctrl-strap-quirk;
+                                        reset-assert-us = <0x64>;
+                                        reset-deassert-us = <0x118>;
+                                        reset-gpios = <&gpio1 0x31 0x1>;
+                                        phandle = <0x96>;
+                                };
+                        };
+                };
+
+                gem1: ethernet@ff0d0000 {
+                        compatible = "xlnx,versal-gem", "cdns,gem";
+                        status = "disabled";
+                        reg = <0x0 0xff0d0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3a 0x4 0x0 0x3a 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x52>,
+                         <&versal_clk 0x59>,
+                         <&versal_clk 0x33>,
+                         <&versal_clk 0x32>,
+                         <&versal_clk 0x2b>;
+                        power-domains = <&versal_firmware 0x1822401a>;
+                        phy-handle = <0x96>;
+                        phy-mode = "rgmii-id";
+                        phandle = <0xb3>;
+                };
+
+                gpio0: gpio@ff0b0000 {
+                        compatible = "xlnx,versal-gpio-1.0";
+                        status = "okay";
+                        reg = <0x0 0xff0b0000 0x0 0x1000>;
+                        interrupts = <0x0 0xd 0x4>;
+                        interrupt-parent = <&imux>;
+                        #gpio-cells = <0x2>;
+                        gpio-controller;
+                        #interrupt-cells = <0x2>;
+                        interrupt-controller;
+                        clocks = <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224023>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_gpio";
+                        emio-gpio-width = [00];
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_gpio_2";
+                        phandle = <0x53>;
+                };
+
+                gpio1: gpio@f1020000 {
+                        compatible = "xlnx,pmc-gpio-1.0";
+                        status = "disabled";
+                        reg = <0x0 0xf1020000 0x0 0x1000>;
+                        interrupts = <0x0 0x7a 0x4>;
+                        interrupt-parent = <&imux>;
+                        #gpio-cells = <0x2>;
+                        gpio-controller;
+                        #interrupt-cells = <0x2>;
+                        interrupt-controller;
+                        clocks = <&versal_clk 0x3d>;
+                        power-domains = <&versal_firmware 0x1822402c>;
+                        phandle = <0x95>;
+                };
+
+                i2c0: i2c@ff020000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "disabled";
+                        reg = <0x0 0xff020000 0x0 0x1000>;
+                        interrupts = <0x0 0xe 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x62>;
+                        power-domains = <&versal_firmware 0x1822401d>;
+                        phandle = <0xb4>;
+                };
+
+                i2c1: i2c@ff030000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "okay";
+                        reg = <0x0 0xff030000 0x0 0x1000>;
+                        interrupts = <0x0 0xf 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x63>;
+                        power-domains = <&versal_firmware 0x1822401e>;
+                        xlnx,rable = <0x0>;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,i2c-clk-freq-hz = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_i2c";
+                        xlnx,iic-board-interface = "custom";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_i2c_1";
+                        phandle = <0x50>;
+                };
+
+                i2c2: i2c@f1000000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "okay";
+                        reg = <0x0 0xf1000000 0x0 0x1000>;
+                        interrupts = <0x0 0x7b 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x3e>;
+                        power-domains = <&versal_firmware 0x1822402d>;
+                        xlnx,rable = <0x0>;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,i2c-clk-freq-hz = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_pmc_i2c";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_i2c_0";
+                        phandle = <0x28>;
+                };
+
+                mc0: memory-controller@f6150000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "okay";
+                        reg = <0x0 0xf6150000 0x0 0x2000 0x0 0xf6070000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        ranges = <0x0 0x0 0x0 0x80000000 0x0 0x40000 0x0 0x7ffc0000>;
+                        phandle = <0xb5>;
+                };
+
+                mc1: memory-controller@f62c0000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf62c0000 0x0 0x2000 0x0 0xf6210000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb6>;
+                };
+
+                mc2: memory-controller@f6430000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf6430000 0x0 0x2000 0x0 0xf6380000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb7>;
+                };
+
+                mc3: memory-controller@f65a0000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf65a0000 0x0 0x2000 0x0 0xf64f0000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb8>;
+                };
+
+                ocm: memory-controller@ff960000 {
+                        compatible = "xlnx,zynqmp-ocmc-1.0";
+                        reg = <0x0 0xff960000 0x0 0x1000>;
+                        interrupts = <0x0 0xa 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb9>;
+                };
+
+                rtc: rtc@f12a0000 {
+                        compatible = "xlnx,zynqmp-rtc";
+                        status = "okay";
+                        reg = <0x0 0xf12a0000 0x0 0x100>;
+                        interrupt-names = "alarm", "sec";
+                        interrupts = <0x0 0x8e 0x4 0x0 0x8f 0x4>;
+                        interrupt-parent = <&imux>;
+                        calibration = <0x7fff>;
+                        power-domains = <&versal_firmware 0x18224034>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_rtc";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_rtc_0";
+                        phandle = <0x38>;
+                };
+
+                sdhci0: mmc@f1040000 {
+                        compatible = "xlnx,versal-8.9a", "arasan,sdhci-8.9a";
+                        status = "disabled";
+                        reg = <0x0 0xf1040000 0x0 0x10000>;
+                        interrupts = <0x0 0x7e 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_xin", "clk_ahb", "gate";
+                        #clock-cells = <0x1>;
+                        clock-output-names = "clk_out_sd0", "clk_in_sd0";
+                        clocks = <&versal_clk 0x3b>,
+                         <&versal_clk 0x52>,
+                         <&versal_clk 0x4a>;
+                        power-domains = <&versal_firmware 0x1822402e>;
+                        phandle = <0xba>;
+                };
+
+                sdhci1: mmc@f1050000 {
+                        compatible = "xlnx,versal-8.9a", "arasan,sdhci-8.9a";
+                        status = "okay";
+                        reg = <0x0 0xf1050000 0x0 0x10000>;
+                        interrupts = <0x0 0x80 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_xin", "clk_ahb", "gate";
+                        #clock-cells = <0x1>;
+                        clock-output-names = "clk_out_sd1", "clk_in_sd1";
+                        clocks = <&versal_clk 0x3c>,
+                         <&versal_clk 0x52>,
+                         <&versal_clk 0x4a>;
+                        power-domains = <&versal_firmware 0x1822402f>;
+                        xlnx,sd-board-interface = "custom";
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,clk-50-ddr-otap-dly = <0x0>;
+                        xlnx,clk-50-sdr-itap-dly = <0x2c>;
+                        xlnx,has-emio = <0x0>;
+                        clock-frequency = <0xbebba31>;
+                        xlnx,clk-100-sdr-otap-dly = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,mio-bank = <0x1>;
+                        xlnx,ip-name = "psv_pmc_sd";
+                        xlnx,bus-width = <0x8>;
+                        xlnx,card-detect = <0x0>;
+                        xlnx,has-wp = <0x0>;
+                        xlnx,has-cd = <0x0>;
+                        xlnx,slot-type = <0x3>;
+                        xlnx,clk-50-sdr-otap-dly = <0x4>;
+                        xlnx,clk-50-ddr-itap-dly = <0x0>;
+                        xlnx,has-power = <0x0>;
+                        xlnx,clk-200-sdr-otap-dly = <0x0>;
+                        xlnx,sdio-clk-freq-hz = <0xbebba31>;
+                        xlnx,write-protect = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_sd_1";
+                        no-1-8-v;
+                        phandle = <0x2a>;
+                };
+
+                serial0: serial@ff000000 {
+                        compatible = "arm,pl011", "arm,primecell";
+                        status = "okay";
+                        reg = <0x0 0xff000000 0x0 0x1000>;
+                        interrupts = <0x0 0x12 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg-io-width = <0x4>;
+                        clock-names = "uartclk", "apb_pclk";
+                        bootph-all;
+                        clocks = <&versal_clk 0x5c>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224021>;
+                        xlnx,has-modem = <0x0>;
+                        xlnx,uart-clk-freq-hz = <0x5f5dd19>;
+                        port-number = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_sbsauart";
+                        xlnx,uart-board-interface = "custom";
+                        xlnx,baudrate = <0x1c200>;
+                        cts-override;
+                        u-boot,dm-pre-reloc;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_sbsauart_0";
+                        phandle = <0x4f>;
+                };
+
+                serial1: serial@ff010000 {
+                        compatible = "arm,pl011", "arm,primecell";
+                        status = "disabled";
+                        reg = <0x0 0xff010000 0x0 0x1000>;
+                        interrupts = <0x0 0x13 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg-io-width = <0x4>;
+                        clock-names = "uartclk", "apb_pclk";
+                        bootph-all;
+                        clocks = <&versal_clk 0x5d>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224022>;
+                        phandle = <0xbb>;
+                };
+
+                smmu: iommu@fd800000 {
+                        compatible = "arm,mmu-500";
+                        status = "okay";
+                        reg = <0x0 0xfd800000 0x0 0x40000>;
+                        stream-match-mask = <0x7c00>;
+                        #iommu-cells = <0x1>;
+                        #global-interrupts = <0x1>;
+                        interrupts = <0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4>;
+                        interrupt-parent = <&imux>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_fpd_smmutcu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_smmutcu_0";
+                        phandle = <0x4d>;
+                };
+
+                ospi: spi@f1010000 {
+                        compatible = "xlnx,versal-ospi-1.0", "cdns,qspi-nor";
+                        status = "disabled";
+                        reg = <0x0 0xf1010000 0x0 0x10000 0x0 0xc0000000 0x0 0x20000000>;
+                        interrupts = <0x0 0x7c 0x4>;
+                        interrupt-parent = <&imux>;
+                        cdns,fifo-depth = <0x100>;
+                        cdns,fifo-width = <0x4>;
+                        cdns,is-dma = <0x1>;
+                        cdns,trigger-address = <0xc0000000>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x3a>;
+                        power-domains = <&versal_firmware 0x1822402a>;
+                        reset-names = "qspi";
+                        resets = <&versal_reset 0xc10402e>;
+                        phandle = <0xbc>;
+                };
+
+                qspi: spi@f1030000 {
+                        compatible = "xlnx,versal-qspi-1.0";
+                        status = "okay";
+                        reg = <0x0 0xf1030000 0x0 0x1000>;
+                        interrupts = <0x0 0x7d 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x39>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822402b>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,baud-rate-div = <0x8>;
+                        num-cs = <0x2>;
+                        xlnx,qspi-clk-freq-hz = <0x11e19751>;
+                        xlnx,rable = <0x0>;
+                        xlnx,bus-width = <0x2>;
+                        xlnx,ip-name = "psv_pmc_qspi";
+                        spi-rx-bus-width = <0x4>;
+                        xlnx,connection-mode = <0x2>;
+                        spi-tx-bus-width = <0x4>;
+                        qspi-fbclk = <0x1>;
+                        xlnx,clock-freq = <0x11e19751>;
+                        xlnx,qspi-baud-rate-div = <0x8>;
+                        xlnx,qspi-mode = <0x2>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_qspi_0";
+                        xlnx,qspi-bus-width = <0x2>;
+                        is-dual = <0x1>;
+                        phandle = <0x29>;
+                };
+
+                spi0: spi@ff040000 {
+                        compatible = "cdns,spi-r1p6";
+                        status = "disabled";
+                        reg = <0x0 0xff040000 0x0 0x1000>;
+                        interrupts = <0x0 0x10 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x5e>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401b>;
+                        phandle = <0xbd>;
+                };
+
+                spi1: spi@ff050000 {
+                        compatible = "cdns,spi-r1p6";
+                        status = "disabled";
+                        reg = <0x0 0xff050000 0x0 0x1000>;
+                        interrupts = <0x0 0x11 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x5f>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401c>;
+                        phandle = <0xbe>;
+                };
+
+                sysmon0: sysmon@f1270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        #io-channel-cells = <0x0>;
+                        reg = <0x0 0xf1270000 0x0 0x4000>;
+                        interrupts = <0x0 0x90 0x4>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        xlnx,nodeid = <0x18224055>;
+                        xlnx,sat-63-desc = "PS , FPD , satellite";
+                        xlnx,sat-34-y = <0x34f8>;
+                        xlnx,sat-17-x = <0x5842>;
+                        xlnx,sat-1-desc = "PMC , system , ADC";
+                        xlnx,sat-9-x = <0x4999>;
+                        xlnx,sat-17-y = <0x1dc4>;
+                        xlnx,sat-19-desc = "Clocking , column , satellite";
+                        xlnx,sat-20-desc = "Clocking , column , satellite";
+                        xlnx,sat-9-y = <0x25ed>;
+                        xlnx,sat-38-x = <0xae9>;
+                        xlnx,sat-38-y = <0x2ff0>;
+                        xlnx,sat-32-desc = "VNOC , satellite";
+                        xlnx,rable = <0x0>;
+                        xlnx,sat-22-x = <0x3a6a>;
+                        xlnx,ip-name = "psv_pmc_sysmon";
+                        xlnx,sat-22-y = <0x19f9>;
+                        xlnx,sat-16-desc = "Clocking , column , satellite";
+                        xlnx,sat-9-desc = "VNOC , satellite";
+                        xlnx,sat-26-x = <0x2b3b>;
+                        xlnx,sat-28-desc = "VNOC , satellite";
+                        xlnx,sat-26-y = <0xe06>;
+                        xlnx,sat-10-x = <0x48b8>;
+                        xlnx,sat-64-x = <0xc>;
+                        xlnx,sat-2-x = <0xc>;
+                        xlnx,sat-10-y = <0x34f8>;
+                        xlnx,sat-64-y = <0xb34>;
+                        xlnx,sat-2-y = <0xb34>;
+                        xlnx,sat-13-desc = "ME , satellite";
+                        xlnx,sat-41-desc = "Clocking , column , satellite";
+                        xlnx,sat-31-x = <0x1c0c>;
+                        xlnx,sat-6-desc = "XPIO , satellite";
+                        xlnx,sat-31-y = <0xe06>;
+                        xlnx,sat-14-x = <0x5842>;
+                        xlnx,sat-6-x = <0x5833>;
+                        xlnx,sat-25-desc = "ME , satellite";
+                        xlnx,sat-14-y = <0x2ff0>;
+                        xlnx,sat-6-y = <0x5ff>;
+                        xlnx,sat-35-x = <0x123a>;
+                        xlnx,sat-10-desc = "ME , satellite";
+                        xlnx,sat-37-desc = "ME , satellite";
+                        xlnx,sat-35-y = <0x34f8>;
+                        xlnx,sat-18-x = <0x5842>;
+                        xlnx,sat-3-desc = "XPIO , satellite";
+                        xlnx,sat-18-y = <0x1795>;
+                        xlnx,sat-22-desc = "VNOC , satellite";
+                        xlnx,sat-40-x = <0xae9>;
+                        xlnx,sat-39-x = <0xae9>;
+                        xlnx,sat-40-y = <0x2389>;
+                        xlnx,sat-39-y = <0x29b7>;
+                        xlnx,sat-23-x = <0x3a6a>;
+                        xlnx,sat-34-desc = "ME , satellite";
+                        xlnx,sat-23-y = <0x25ed>;
+                        xlnx,sat-18-desc = "Clocking , column , satellite";
+                        xlnx,sat-27-x = <0x2b3b>;
+                        xlnx,sat-27-y = <0x19f9>;
+                        xlnx,sat-11-x = <0x40ef>;
+                        xlnx,sat-3-x = <0x1153>;
+                        xlnx,sat-31-desc = "VNOC , satellite";
+                        xlnx,sat-11-y = <0x34f8>;
+                        xlnx,sat-3-y = <0x5ff>;
+                        status = "okay";
+                        xlnx,sat-32-x = <0x1c0c>;
+                        xlnx,sat-15-desc = "Clocking , column , satellite";
+                        xlnx,sat-32-y = <0x19f9>;
+                        xlnx,sat-15-x = <0x5842>;
+                        xlnx,sat-8-desc = "VNOC , satellite";
+                        xlnx,sat-7-x = <0x4999>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_sysmon_0";
+                        xlnx,sat-15-y = <0x29b7>;
+                        xlnx,sat-7-y = <0xe06>;
+                        xlnx,sat-27-desc = "VNOC , satellite";
+                        xlnx,sat-36-x = <0xa71>;
+                        xlnx,sat-36-y = <0x34f8>;
+                        xlnx,sat-12-desc = "ME , satellite";
+                        xlnx,sat-19-x = <0x5842>;
+                        xlnx,sat-20-x = <0x5842>;
+                        xlnx,sat-40-desc = "Clocking , column , satellite";
+                        xlnx,sat-39-desc = "Clocking , column , satellite";
+                        xlnx,sat-19-y = <0x11d0>;
+                        xlnx,sat-20-y = <0xba1>;
+                        xlnx,sat-5-desc = "XPIO , satellite";
+                        xlnx,sat-41-x = <0xae9>;
+                        xlnx,sat-24-desc = "ME , satellite";
+                        xlnx,sat-41-y = <0x1dc4>;
+                        xlnx,sat-24-x = <0x3926>;
+                        xlnx,sat-24-y = <0x34f8>;
+                        xlnx,sat-36-desc = "ME , satellite";
+                        xlnx,sat-64-desc = "PS , LPD , satellite";
+                        xlnx,sat-2-desc = "PMC , user , ADC";
+                        xlnx,sat-28-x = <0x2b3b>;
+                        xlnx,sat-21-desc = "VNOC , satellite";
+                        xlnx,sat-28-y = <0x25ed>;
+                        xlnx,sat-12-x = <0x5081>;
+                        xlnx,sat-4-x = <0x28f3>;
+                        xlnx,sat-12-y = <0x34f8>;
+                        xlnx,sat-4-y = <0x5ff>;
+                        xlnx,sat-33-desc = "VNOC , satellite";
+                        xlnx,sat-33-x = <0x1c0c>;
+                        xlnx,sat-33-y = <0x25ed>;
+                        xlnx,sat-16-x = <0x5842>;
+                        xlnx,sat-17-desc = "Clocking , column , satellite";
+                        xlnx,sat-8-x = <0x4999>;
+                        xlnx,sat-16-y = <0x2389>;
+                        xlnx,sat-8-y = <0x19f9>;
+                        xlnx,sat-37-x = <0x2a8>;
+                        xlnx,sat-30-desc = "ME , satellite";
+                        xlnx,sat-29-desc = "ME , satellite";
+                        xlnx,sat-37-y = <0x34f8>;
+                        xlnx,sat-21-x = <0x3a6a>;
+                        xlnx,sat-14-desc = "Clocking , column , satellite";
+                        xlnx,sat-21-y = <0xe06>;
+                        xlnx,sat-7-desc = "VNOC , satellite";
+                        xlnx,sat-26-desc = "VNOC , satellite";
+                        xlnx,sat-25-x = <0x315e>;
+                        xlnx,sat-25-y = <0x34f8>;
+                        xlnx,sat-63-x = <0xc>;
+                        xlnx,sat-11-desc = "ME , satellite";
+                        xlnx,sat-1-x = <0xc>;
+                        xlnx,sat-63-y = <0xb34>;
+                        xlnx,sat-38-desc = "Clocking , column , satellite";
+                        xlnx,sat-1-y = <0xb34>;
+                        xlnx,sat-4-desc = "XPIO , satellite";
+                        xlnx,sat-30-x = <0x21cc>;
+                        xlnx,sat-29-x = <0x2995>;
+                        xlnx,sat-30-y = <0x34f8>;
+                        xlnx,sat-29-y = <0x34f8>;
+                        xlnx,sat-13-x = <0x584a>;
+                        xlnx,sat-23-desc = "VNOC , satellite";
+                        xlnx,sat-5-x = <0x4093>;
+                        xlnx,sat-13-y = <0x34f8>;
+                        xlnx,sat-5-y = <0x5ff>;
+                        xlnx,sat-35-desc = "ME , satellite";
+                        xlnx,sat-34-x = <0x1a03>;
+                        phandle = <0x37>;
+                };
+
+                sysmon1: sysmon@109270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x9270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18225055>;
+                        phandle = <0xbf>;
+                };
+
+                sysmon2: sysmon@111270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x11270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18226055>;
+                        phandle = <0xc0>;
+                };
+
+                sysmon3: sysmon@119270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x19270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18227055>;
+                        phandle = <0xc1>;
+                };
+
+                ttc0: timer@ff0e0000 {
+                        compatible = "cdns,ttc";
+                        status = "okay";
+                        interrupts = <0x0 0x25 0x4 0x0 0x26 0x4 0x0 0x27 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff0e0000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x27>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224024>;
+                        xlnx,ttc-clk2-clksrc = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_ttc";
+                        xlnx,ttc-clk1-clksrc = <0x0>;
+                        xlnx,ttc-clk0-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-clk1-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-clk2-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-board-interface = "custom";
+                        xlnx,clock-freq = <0x8f0cba9>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ttc_0";
+                        xlnx,ttc-clk0-clksrc = <0x0>;
+                        phandle = <0x55>;
+                };
+
+                ttc1: timer@ff0f0000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x28 0x4 0x0 0x29 0x4 0x0 0x2a 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff0f0000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x28>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224025>;
+                        phandle = <0xc2>;
+                };
+
+                ttc2: timer@ff100000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x2b 0x4 0x0 0x2c 0x4 0x0 0x2d 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff100000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x29>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224026>;
+                        phandle = <0xc3>;
+                };
+
+                ttc3: timer@ff110000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x2e 0x4 0x0 0x2f 0x4 0x0 0x30 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff110000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x2a>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224027>;
+                        phandle = <0xc4>;
+                };
+
+                usb0: usb@ff9d0000 {
+                        compatible = "xlnx,versal-dwc3";
+                        status = "okay";
+                        reg = <0x0 0xff9d0000 0x0 0x100>;
+                        clock-names = "bus_clk", "ref_clk";
+                        ranges;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        clocks = <&versal_clk 0x5b>,
+                         <&versal_clk 0x68>;
+                        power-domains = <&versal_firmware 0x18224018>;
+                        resets = <&versal_reset 0xc104036>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_usb";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_usb_0";
+                        phandle = <0x60>;
+
+                        dwc3_0: usb@fe200000 {
+                                compatible = "snps,dwc3";
+                                status = "okay";
+                                reg = <0x0 0xfe200000 0x0 0x10000>;
+                                interrupt-names = "host", "peripheral", "otg", "wakeup";
+                                interrupts = <0x0 0x16 0x4 0x0 0x16 0x4 0x0 0x1a 0x4 0x0 0x4a 0x4>;
+                                snps,dis_u2_susphy_quirk;
+                                snps,dis_u3_susphy_quirk;
+                                snps,quirk-frame-length-adjustment = <0x20>;
+                                clock-names = "ref";
+                                clocks = <&versal_clk 0x5b>;
+                                xlnx,rable = <0x0>;
+                                xlnx,is-cache-coherent = <0x0>;
+                                xlnx,ip-name = "psv_usb_xhci";
+                                xlnx,name = "versal_cips_0_pspmc_0_psv_usb_xhci_0";
+                                dr_mode = "host";
+                                maximum-speed = "high-speed";
+                                snps,usb3_lpm_capable;
+                                phandle = <0x4e>;
+                        };
+                };
+
+                cpm_pciea: pci@fca10000 {
+                        device_type = "pci";
+                        #address-cells = <0x3>;
+                        #interrupt-cells = <0x1>;
+                        #size-cells = <0x2>;
+                        compatible = "xlnx,versal-cpm-host-1.00";
+                        status = "okay";
+                        interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc_0 0x0>,
+                         <0x0 0x0 0x0 0x2 &pcie_intc_0 0x1>,
+                         <0x0 0x0 0x0 0x3 &pcie_intc_0 0x2>,
+                         <0x0 0x0 0x0 0x4 &pcie_intc_0 0x3>;
+                        interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+                        interrupt-names = "misc";
+                        interrupts = <0x0 0x48 0x4>;
+                        xlnx,csr-slcr = <0x6 0x0>;
+                        xlnx,num-of-bars = <0x2>;
+                        xlnx,port-type = <0x1>;
+                        interrupt-parent = <&imux>;
+                        bus-range = <0x0 0xff>;
+                        ranges = <0x2000000 0x0 0xe0010000 0x0 0xe0010000 0x0 0x10000000 0x43000000 0x80 0x0 0x80 0x0 0x0 0x80000000>;
+                        msi-map = <0x0 0x4 0x0 0x10000>;
+                        reg = <0x6 0x0 0x0 0x1000000 0x0 0xfca10000 0x0 0x1000>;
+                        reg-names = "cfg", "cpm_slcr";
+                        xlnx,rable = <0x0>;
+                        xlnx,cpm5-slcr-addr = <0xfcdd0000>;
+                        xlnx,ip-name = "psv_cpm";
+                        xlnx,cpm-slcr = <0xfca10000>;
+                        xlnx,cpm5-dma0-csr-addr = <0xfce20000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_cpm";
+                        phandle = <0x41>;
+
+                        pcie_intc_0: interrupt-controller {
+                                #address-cells = <0x0>;
+                                #interrupt-cells = <0x1>;
+                                interrupt-controller;
+                                phandle = <0x98>;
+                        };
+                };
+
+                cpm5_pcie: pcie@fcdd0000 {
+                        device_type = "pci";
+                        #address-cells = <0x3>;
+                        #interrupt-cells = <0x1>;
+                        #size-cells = <0x2>;
+                        compatible = "xlnx,versal-cpm5-host";
+                        status = "disabled";
+                        interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc_2 0x0>,
+                         <0x0 0x0 0x0 0x2 &pcie_intc_2 0x1>,
+                         <0x0 0x0 0x0 0x3 &pcie_intc_2 0x2>,
+                         <0x0 0x0 0x0 0x4 &pcie_intc_2 0x3>;
+                        interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+                        interrupt-names = "misc";
+                        interrupts = <0x0 0x48 0x4>;
+                        xlnx,csr-slcr = <0xfce20000>;
+                        xlnx,num-of-bars = <0x2>;
+                        xlnx,port-type = <0x1>;
+                        interrupt-parent = <&imux>;
+                        bus-range = <0x0 0xff>;
+                        ranges = <0x2000000 0x0 0xe0000000 0x0 0xe0000000 0x0 0x10000000 0x43000000 0x80 0x0 0x80 0x0 0x0 0x80000000>;
+                        msi-map = <0x0 0x4 0x0 0x10000>;
+                        reg = <0x6 0x0 0x0 0x1000000 0x0 0xfcdd0000 0x0 0x1000 0x0 0xfce20000 0x0 0x1000000>;
+                        reg-names = "cfg", "cpm_slcr", "cpm_csr";
+                        phandle = <0xc5>;
+
+                        pcie_intc_2: interrupt-controller {
+                                #address-cells = <0x0>;
+                                #interrupt-cells = <0x1>;
+                                interrupt-controller;
+                                phandle = <0x99>;
+                        };
+                };
+
+                watchdog: watchdog@fd4d0000 {
+                        compatible = "xlnx,versal-wwdt";
+                        status = "disabled";
+                        reg = <0x0 0xfd4d0000 0x0 0x10000>;
+                        interrupt-names = "wdt", "wwdt_reset_pending", "gwdt", "gwdt_reset_pending";
+                        interrupts = <0x0 0x64 0x1 0x0 0x6d 0x1 0x0 0x6c 0x1 0x0 0x6e 0x1>;
+                        interrupt-parent = <&imux>;
+                        timeout-sec = <0x1e>;
+                        clocks = <&versal_clk 0x4c>;
+                        power-domains = <&versal_firmware 0x18224029>;
+                        phandle = <0xc6>;
+                };
+
+                watchdog1: watchdog@ff120000 {
+                        compatible = "xlnx,versal-wwdt";
+                        status = "disabled";
+                        reg = <0x0 0xff120000 0x0 0x10000>;
+                        interrupt-parent = <&imux>;
+                        interrupt-names = "wdt", "wwdt_reset_pending", "gwdt", "gwdt_reset_pending";
+                        interrupts = <0x0 0x31 0x1 0x0 0x45 0x1 0x0 0x46 0x4 0x0 0x47 0x4>;
+                        timeout-sec = <0x1e>;
+                        clocks = <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224028>;
+                        phandle = <0xc7>;
+                };
+
+                xilsem_edac: edac@f2014050 {
+                        compatible = "xlnx,versal-xilsem-edac";
+                        status = "disabled";
+                        reg = <0x0 0xf2014050 0x0 0xc4>;
+                        phandle = <0xc8>;
+                };
+
+                dma0: pmcdma@f11c0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-csudma-1.0";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x83 0x4>;
+                        reg = <0x0 0xf11c0000 0x0 0x10000>;
+                        xlnx,dma-type = <0x1>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_dma";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_dma_0";
+                        phandle = <0x2c>;
+                };
+
+                dma1: pmcdma@f11d0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-csudma-1.0";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x84 0x4>;
+                        reg = <0x0 0xf11d0000 0x0 0x10000>;
+                        xlnx,dma-type = <0x2>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_dma";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_dma_1";
+                        phandle = <0x2d>;
+                };
+
+                iomodule0: iomodule@f0280000 {
+                        status = "okay";
+                        compatible = "xlnx,iomodule-3.1";
+                        reg = <0x0 0xf0280000 0x0 0x1000 0xffffffff 0xffffffff 0x0 0xe0000>;
+                        xlnx,intc-has-fast = <0x0>;
+                        xlnx,intc-base-vectors = <0xf0240000>;
+                        xlnx,intc-addr-width = <0x20>;
+                        xlnx,intc-level-edge = <0x7fff>;
+                        xlnx,clock-freq = <0x5f5e100>;
+                        xlnx,uart-baudrate = <0x1c200>;
+                        xlnx,pit-used = <0x1 0x1 0x1 0x1>;
+                        xlnx,pit-size = <0x20 0x20 0x20 0x20>;
+                        xlnx,pit-mask = <0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+                        xlnx,pit-prescaler = <0x9 0x0 0x9 0x0>;
+                        xlnx,pit-readable = <0x1 0x1 0x1 0x1>;
+                        xlnx,gpo-init = <0x0 0x0 0x0 0x0>;
+                        xlnx,options = <0x1>;
+                        xlnx,max-intr-size = <0x20>;
+                        xlnx,gpo4-size = <0x20>;
+                        xlnx,tmr = <0x0>;
+                        xlnx,pit1-readable = <0x1>;
+                        xlnx,mask = <0xfffff000>;
+                        xlnx,pit2-prescaler = <0x0>;
+                        xlnx,gpi3-interrupt = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,intc-positive = <0xffff>;
+                        xlnx,ip-name = "iomodule";
+                        xlnx,gpo1-size = <0x3>;
+                        xlnx,pit3-size = <0x20>;
+                        xlnx,fit3-interrupt = <0x0>;
+                        xlnx,fit1-no-clocks = <0x1848>;
+                        xlnx,gpi2-size = <0x20>;
+                        xlnx,pit2-readable = <0x1>;
+                        xlnx,intc-irq-connection = <0x0>;
+                        xlnx,uart-tx-interrupt = <0x1>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,pit2-interrupt = <0x1>;
+                        xlnx,gpo4-init = <0x0>;
+                        xlnx,pit3-readable = <0x1>;
+                        xlnx,pit3-prescaler = <0x9>;
+                        xlnx,gpi4-interrupt = <0x0>;
+                        xlnx,gpo1-init = <0x0>;
+                        xlnx,use-io-bus = <0x0>;
+                        xlnx,use-gpo1 = <0x1>;
+                        xlnx,fit4-interrupt = <0x0>;
+                        xlnx,gpo3-size = <0x20>;
+                        xlnx,use-gpo2 = <0x0>;
+                        xlnx,uart-data-bits = <0x8>;
+                        xlnx,gpio1-board-interface = "Custom";
+                        xlnx,use-gpo3 = <0x0>;
+                        xlnx,fit2-no-clocks = <0x1848>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,use-gpo4 = <0x0>;
+                        xlnx,gpi4-size = <0x20>;
+                        xlnx,gpio3-board-interface = "Custom";
+                        xlnx,uart-rx-interrupt = <0x1>;
+                        xlnx,uart-error-interrupt = <0x1>;
+                        xlnx,gpio4-board-interface = "Custom";
+                        xlnx,pit4-readable = <0x1>;
+                        xlnx,intc-use-irq-out = <0x0>;
+                        xlnx,use-board-flow;
+                        xlnx,pit2-size = <0x20>;
+                        xlnx,intc-intr-size = <0x10>;
+                        xlnx,intc-use-ext-intr = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_iomodule_0";
+                        xlnx,gpi1-size = <0x20>;
+                        xlnx,edk-special = "INTR_CTRL";
+                        xlnx,pit3-interrupt = <0x1>;
+                        xlnx,use-gpi1 = <0x0>;
+                        xlnx,gpi1-interrupt = <0x0>;
+                        xlnx,use-gpi2 = <0x0>;
+                        xlnx,use-gpi3 = <0x0>;
+                        xlnx,use-gpi4 = <0x0>;
+                        xlnx,fit1-interrupt = <0x0>;
+                        xlnx,pit4-prescaler = <0x0>;
+                        xlnx,gpo3-init = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,fit3-no-clocks = <0x1848>;
+                        xlnx,use-uart-rx = <0x1>;
+                        xlnx,instance = "iomodule_0";
+                        xlnx,uart-prog-baudrate = <0x1>;
+                        xlnx,use-pit1 = <0x1>;
+                        xlnx,gpo2-size = <0x20>;
+                        xlnx,use-pit2 = <0x1>;
+                        xlnx,pit4-size = <0x20>;
+                        xlnx,use-pit3 = <0x1>;
+                        xlnx,use-pit4 = <0x1>;
+                        xlnx,pit4-interrupt = <0x1>;
+                        xlnx,gpi3-size = <0x20>;
+                        xlnx,intc-async-intr = <0xffff>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,gpi2-interrupt = <0x0>;
+                        xlnx,pit1-prescaler = <0x9>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,use-fit1 = <0x0>;
+                        xlnx,pit1-size = <0x20>;
+                        xlnx,intc-num-sync-ff = <0x2>;
+                        xlnx,uart-board-interface = "rs232_uart";
+                        xlnx,use-fit2 = <0x0>;
+                        xlnx,fit2-interrupt = <0x0>;
+                        xlnx,use-fit3 = <0x0>;
+                        xlnx,use-fit4 = <0x0>;
+                        xlnx,uart-use-parity = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,fit4-no-clocks = <0x1848>;
+                        xlnx,uart-odd-parity = <0x0>;
+                        xlnx,freq = <0x5f5e100>;
+                        xlnx,use-uart-tx = <0x1>;
+                        xlnx,pit1-interrupt = <0x1>;
+                        xlnx,gpo2-init = <0x0>;
+                        xlnx,io-mask = <0xfffe0000>;
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x7c>;
+                };
+
+                ipi_pmc: mailbox@ff320000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1b 0x4>;
+                        reg = <0x0 0xff320000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x2>;
+                        xlnx,ipi-id = <0x1>;
+                        xlnx,ipi-buf-index = <0x1>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "PMC";
+                        xlnx,buffer-base = <0xff3f0200>;
+                        xlnx,buffer-index = <0x1>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3b>;
+                        xlnx,bit-position = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_pmc";
+                        phandle = <0x77>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f02a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0280>;
+                                phandle = <0xc9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f02e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f02c0>;
+                                phandle = <0xca>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0320>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0300>;
+                                phandle = <0xcb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0360>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0340>;
+                                phandle = <0xcc>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f03a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0380>;
+                                phandle = <0xcd>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f03e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f03c0>;
+                                phandle = <0xce>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xcf>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0260>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0240>;
+                                phandle = <0xd0>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xd1>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0220>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0200>;
+                                phandle = <0xd2>;
+                        };
+                };
+
+                ipi_pmc_nobuf: mailbox@ff390000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1c 0x4>;
+                        reg = <0x0 0xff390000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x100>;
+                        xlnx,ipi-id = <0x8>;
+                        xlnx,ipi-buf-index = <0xffff>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "PMC";
+                        xlnx,buffer-base = "NIL";
+                        xlnx,buffer-index = "NIL";
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3c>;
+                        xlnx,bit-position = <0x8>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf";
+                        phandle = <0x78>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                phandle = <0xd3>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                phandle = <0xd4>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                phandle = <0xd5>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                phandle = <0xd6>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                phandle = <0xd7>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                phandle = <0xd8>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xd9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                phandle = <0xda>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xdb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                phandle = <0xdc>;
+                        };
+                };
+
+                ipi_psm: mailbox@ff310000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1d 0x4>;
+                        reg = <0x0 0xff310000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x1>;
+                        xlnx,ipi-id = <0x0>;
+                        xlnx,ipi-buf-index = <0x0>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "PSM";
+                        xlnx,buffer-base = <0xff3f0000>;
+                        xlnx,buffer-index = <0x0>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3d>;
+                        xlnx,bit-position = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_psm";
+                        phandle = <0x7e>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f00a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0080>;
+                                phandle = <0xdd>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f00e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f00c0>;
+                                phandle = <0xde>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0120>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0100>;
+                                phandle = <0xdf>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0160>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0140>;
+                                phandle = <0xe0>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f01a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0180>;
+                                phandle = <0xe1>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f01e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f01c0>;
+                                phandle = <0xe2>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xe3>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0060>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0040>;
+                                phandle = <0xe4>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xe5>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0020>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0000>;
+                                phandle = <0xe6>;
+                        };
+                };
+
+                ipi0: mailbox@ff330000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1e 0x4>;
+                        reg = <0x0 0xff330000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x4>;
+                        xlnx,ipi-id = <0x2>;
+                        xlnx,ipi-buf-index = <0x2>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0400>;
+                        xlnx,buffer-index = <0x2>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3e>;
+                        xlnx,bit-position = <0x2>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_0";
+                        phandle = <0x5>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f04a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0480>;
+                                phandle = <0xe7>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f04e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f04c0>;
+                                phandle = <0xe8>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0520>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0500>;
+                                phandle = <0xe9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0560>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0540>;
+                                phandle = <0xea>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f05a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0580>;
+                                phandle = <0xeb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f05e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f05c0>;
+                                phandle = <0xec>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xed>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0460>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0440>;
+                                phandle = <0xee>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xef>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0420>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0400>;
+                                phandle = <0xf0>;
+                        };
+                };
+
+                ipi1: mailbox@ff340000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1f 0x4>;
+                        reg = <0x0 0xff340000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x8>;
+                        xlnx,ipi-id = <0x3>;
+                        xlnx,ipi-buf-index = <0x3>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0600>;
+                        xlnx,buffer-index = <0x3>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3f>;
+                        xlnx,bit-position = <0x3>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_1";
+                        phandle = <0x6>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f06a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0680>;
+                                phandle = <0xf1>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f06e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f06c0>;
+                                phandle = <0xf2>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0720>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0700>;
+                                phandle = <0xf3>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0760>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0740>;
+                                phandle = <0xf4>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f07a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0780>;
+                                phandle = <0xf5>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f07e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f07c0>;
+                                phandle = <0xf6>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xf7>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0660>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0640>;
+                                phandle = <0xf8>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xf9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0620>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0600>;
+                                phandle = <0xfa>;
+                        };
+                };
+
+                ipi2: mailbox@ff350000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x20 0x4>;
+                        reg = <0x0 0xff350000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x10>;
+                        xlnx,ipi-id = <0x4>;
+                        xlnx,ipi-buf-index = <0x4>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0800>;
+                        xlnx,buffer-index = <0x4>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x40>;
+                        xlnx,bit-position = <0x4>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_2";
+                        phandle = <0x7>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f08a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0880>;
+                                phandle = <0xfb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f08e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f08c0>;
+                                phandle = <0xfc>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0920>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0900>;
+                                phandle = <0xfd>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0960>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0940>;
+                                phandle = <0xfe>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f09a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0980>;
+                                phandle = <0xff>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f09e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f09c0>;
+                                phandle = <0x100>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x101>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0860>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0840>;
+                                phandle = <0x102>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x103>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0820>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0800>;
+                                phandle = <0x104>;
+                        };
+                };
+
+                ipi3: mailbox@ff360000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x21 0x4>;
+                        reg = <0x0 0xff360000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x20>;
+                        xlnx,ipi-id = <0x5>;
+                        xlnx,ipi-buf-index = <0x5>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0a00>;
+                        xlnx,buffer-index = <0x5>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x41>;
+                        xlnx,bit-position = <0x5>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_3";
+                        phandle = <0x8>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0aa0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0a80>;
+                                phandle = <0x105>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ae0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0ac0>;
+                                phandle = <0x106>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0b20>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0b00>;
+                                phandle = <0x107>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0b60>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0b40>;
+                                phandle = <0x108>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ba0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0b80>;
+                                phandle = <0x109>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0be0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0bc0>;
+                                phandle = <0x10a>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x10b>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0a60>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0a40>;
+                                phandle = <0x10c>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x10d>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0a20>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0a00>;
+                                phandle = <0x10e>;
+                        };
+                };
+
+                ipi4: mailbox@ff370000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x22 0x4>;
+                        reg = <0x0 0xff370000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x40>;
+                        xlnx,ipi-id = <0x6>;
+                        xlnx,ipi-buf-index = <0x6>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0c00>;
+                        xlnx,buffer-index = <0x6>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x42>;
+                        xlnx,bit-position = <0x6>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_4";
+                        phandle = <0x9>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ca0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0c80>;
+                                phandle = <0x10f>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ce0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0cc0>;
+                                phandle = <0x110>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0d20>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0d00>;
+                                phandle = <0x111>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0d60>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0d40>;
+                                phandle = <0x112>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0da0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0d80>;
+                                phandle = <0x113>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0de0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0dc0>;
+                                phandle = <0x114>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x115>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0c60>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0c40>;
+                                phandle = <0x116>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x117>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0c20>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0c00>;
+                                phandle = <0x118>;
+                        };
+                };
+
+                ipi5: mailbox@ff380000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x23 0x4>;
+                        reg = <0x0 0xff380000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x80>;
+                        xlnx,ipi-id = <0x7>;
+                        xlnx,ipi-buf-index = <0x7>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0e00>;
+                        xlnx,buffer-index = <0x7>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x43>;
+                        xlnx,bit-position = <0x7>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_5";
+                        phandle = <0xa>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ea0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0e80>;
+                                phandle = <0x119>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ee0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0ec0>;
+                                phandle = <0x11a>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0f20>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0f00>;
+                                phandle = <0x11b>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0f60>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0f40>;
+                                phandle = <0x11c>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0fa0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0f80>;
+                                phandle = <0x11d>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0fe0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0fc0>;
+                                phandle = <0x11e>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x11f>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0e60>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0e40>;
+                                phandle = <0x120>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x121>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0e20>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0e00>;
+                                phandle = <0x122>;
+                        };
+                };
+
+                ipi6: mailbox@ff3a0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x24 0x4>;
+                        reg = <0x0 0xff3a0000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x200>;
+                        xlnx,ipi-id = <0x9>;
+                        xlnx,ipi-buf-index = <0xffff>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = "NIL";
+                        xlnx,buffer-index = "NIL";
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x44>;
+                        xlnx,bit-position = <0x9>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_6";
+                        phandle = <0xb>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                phandle = <0x123>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                phandle = <0x124>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                phandle = <0x125>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                phandle = <0x126>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                phandle = <0x127>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                phandle = <0x128>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x129>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                phandle = <0x12a>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x12b>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                phandle = <0x12c>;
+                        };
+                };
+
+                coresight: coresight@f0800000 {
+                        compatible = "xlnx,coresight-1.0";
+                        status = "okay";
+                        reg = <0x0 0xf0800000 0x0 0x10000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_coresight";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_0";
+                        phandle = <0xf>;
+                };
+
+                versal_cips_0_cpm_0_psv_cpm: versal_cips_0_cpm_0_psv_cpm@0 {
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-2 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-3 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-4 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-1 = <0x0>;
+                        xlnx,cpm-req-agents-0-enable = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-2 = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-3 = <0x0>;
+                        xlnx,ip-name = "psv_cpm";
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-7 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-4 = <0x0>;
+                        reg = <0x0 0xfc000000 0x0 0x1000000>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-7 = <0x0>;
+                        xlnx,axibar-0 = <0x0>;
+                        xlnx,axibar-1 = <0x0>;
+                        xlnx,cpm-axi-slv-xdma0-base-addrr-h = <0x6>;
+                        xlnx,cpm-ccix-port-aggregation-enable = <0x0>;
+                        xlnx,cpm-pcie1-port-type = <0x0>;
+                        xlnx,cpm-pcie1-edr-link-speed = <0x0>;
+                        xlnx,cpm-pcie1-axibar-num = <0x1>;
+                        compatible = "xlnx,psv-cpm-1.0";
+                        xlnx,cpm-axi-slv-xdma0-base-addrr-l = <0x11000000>;
+                        xlnx,axibar-num = <0x1>;
+                        xlnx,nocpspcie0-region0 = <0x6 0x0>;
+                        xlnx,nocpspcie1-region0 = <0x6 0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-highaddr-0 = <0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-highaddr-1 = <0x0>;
+                        xlnx,cpm-pcie0-edr-link-speed = <0x0>;
+                        xlnx,cpm-axi-slv-bridge0-base-addrr-h = <0x6>;
+                        xlnx,cpm-pcie0-controller-enable = <0x1>;
+                        xlnx,axibar-highaddr-0 = <0xfff>;
+                        xlnx,axibar-highaddr-1 = <0x0>;
+                        xlnx,cpm-axi-slv-bridge0-base-addrr-l = <0x0>;
+                        status = "okay";
+                        xlnx,cpm-ccix-partial-cacheline-support = <0x0>;
+                        xlnx,name = "versal_cips_0_cpm_0_psv_cpm";
+                        xlnx,cpm-pcie1-pf0-cfg-dev-id = "B03F";
+                        xlnx,cpm-ccix-select-agent = <0x0>;
+                        xlnx,is-hierarchy;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-0 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-1 = <0x4>;
+                        xlnx,cpm-revision-number = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-2 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-3 = <0x4>;
+                        xlnx,cpm-pcie1-controller-enable = <0x0>;
+                        xlnx,cpm-pcie0-pf0-cfg-dev-id = "B03C";
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-4 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-5 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-6 = <0x4>;
+                        xlnx,cpm-num-ccix-credit-links = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-7 = <0x4>;
+                        xlnx,cpm-num-home-or-slave-agents = <0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-baseaddr-0 = <0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-baseaddr-1 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-1 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-0 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-2 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-1 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-3 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-1 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-2 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-4 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-3 = <0x4>;
+                        xlnx,cpm-axi-slv-multq0-base-addrr-h = <0x6>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-2 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-4 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-3 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-5 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-4 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-7 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-6 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-7 = <0x4>;
+                        xlnx,cpm-axi-slv-multq0-base-addrr-l = <0x10000000>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-7 = <0x0>;
+                        xlnx,cpm-req-agents-1-enable = <0x0>;
+                        xlnx,cpm-pcie0-port-type = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-1 = <0x0>;
+                        phandle = <0x12d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_apu_0: versal_cips_0_pspmc_0_psv_apu_0@fd5c0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-apu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_apu";
+                        reg = <0x0 0xfd5c0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_apu_0";
+                        phandle = <0x47>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_cti: versal_cips_0_pspmc_0_psv_coresight_a720_cti@f0d10000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-cti-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_cti";
+                        reg = <0x0 0xf0d10000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_cti";
+                        phandle = <0x18>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_dbg: versal_cips_0_pspmc_0_psv_coresight_a720_dbg@f0d00000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-dbg-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_dbg";
+                        reg = <0x0 0xf0d00000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_dbg";
+                        phandle = <0x17>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_etm: versal_cips_0_pspmc_0_psv_coresight_a720_etm@f0d30000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-etm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_etm";
+                        reg = <0x0 0xf0d30000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_etm";
+                        phandle = <0x1a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_pmu: versal_cips_0_pspmc_0_psv_coresight_a720_pmu@f0d20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-pmu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_pmu";
+                        reg = <0x0 0xf0d20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_pmu";
+                        phandle = <0x19>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_cti: versal_cips_0_pspmc_0_psv_coresight_a721_cti@f0d50000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-cti-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_cti";
+                        reg = <0x0 0xf0d50000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_cti";
+                        phandle = <0x1c>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_dbg: versal_cips_0_pspmc_0_psv_coresight_a721_dbg@f0d40000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-dbg-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_dbg";
+                        reg = <0x0 0xf0d40000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_dbg";
+                        phandle = <0x1b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_etm: versal_cips_0_pspmc_0_psv_coresight_a721_etm@f0d70000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-etm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_etm";
+                        reg = <0x0 0xf0d70000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_etm";
+                        phandle = <0x1e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_pmu: versal_cips_0_pspmc_0_psv_coresight_a721_pmu@f0d60000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-pmu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_pmu";
+                        reg = <0x0 0xf0d60000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_pmu";
+                        phandle = <0x1d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_cti: versal_cips_0_pspmc_0_psv_coresight_apu_cti@f0ca0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-cti-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_cti";
+                        reg = <0x0 0xf0ca0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_cti";
+                        phandle = <0x16>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_ela: versal_cips_0_pspmc_0_psv_coresight_apu_ela@f0c60000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-ela-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_ela";
+                        reg = <0x0 0xf0c60000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_ela";
+                        phandle = <0x15>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_etf: versal_cips_0_pspmc_0_psv_coresight_apu_etf@f0c30000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-etf-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_etf";
+                        reg = <0x0 0xf0c30000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_etf";
+                        phandle = <0x14>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_fun: versal_cips_0_pspmc_0_psv_coresight_apu_fun@f0c20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-fun-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_fun";
+                        reg = <0x0 0xf0c20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_fun";
+                        phandle = <0x13>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_atm: versal_cips_0_pspmc_0_psv_coresight_cpm_atm@f0f80000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-atm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_atm";
+                        reg = <0x0 0xf0f80000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_atm";
+                        phandle = <0x25>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a: versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a@f0fa0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-cti2a-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_cti2a";
+                        reg = <0x0 0xf0fa0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a";
+                        phandle = <0x26>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d: versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d@f0fd0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-cti2d-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_cti2d";
+                        reg = <0x0 0xf0fd0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d";
+                        phandle = <0x27>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a@f0f40000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2a-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2a";
+                        reg = <0x0 0xf0f40000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a";
+                        phandle = <0x21>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b@f0f50000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2b-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2b";
+                        reg = <0x0 0xf0f50000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b";
+                        phandle = <0x22>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c@f0f60000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2c-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2c";
+                        reg = <0x0 0xf0f60000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c";
+                        phandle = <0x23>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d@f0f70000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2d-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2d";
+                        reg = <0x0 0xf0f70000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d";
+                        phandle = <0x24>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_fun: versal_cips_0_pspmc_0_psv_coresight_cpm_fun@f0f20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-fun-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_fun";
+                        reg = <0x0 0xf0f20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_fun";
+                        phandle = <0x20>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_rom: versal_cips_0_pspmc_0_psv_coresight_cpm_rom@f0f00000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-rom-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_rom";
+                        reg = <0x0 0xf0f00000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_rom";
+                        phandle = <0x1f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_fpd_atm: versal_cips_0_pspmc_0_psv_coresight_fpd_atm@f0b80000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-fpd-atm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_fpd_atm";
+                        reg = <0x0 0xf0b80000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_fpd_atm";
+                        phandle = <0x12>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_fpd_stm: versal_cips_0_pspmc_0_psv_coresight_fpd_stm@f0b70000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-fpd-stm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_fpd_stm";
+                        reg = <0x0 0xf0b70000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_fpd_stm";
+                        phandle = <0x11>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_lpd_atm: versal_cips_0_pspmc_0_psv_coresight_lpd_atm@f0980000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-lpd-atm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_lpd_atm";
+                        reg = <0x0 0xf0980000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_lpd_atm";
+                        phandle = <0x10>;
+                };
+
+                versal_cips_0_pspmc_0_psv_crf_0: versal_cips_0_pspmc_0_psv_crf_0@fd1a0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-crf-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_crf";
+                        reg = <0x0 0xfd1a0000 0x0 0x140000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_crf_0";
+                        phandle = <0x43>;
+                };
+
+                versal_cips_0_pspmc_0_psv_crl_0: versal_cips_0_pspmc_0_psv_crl_0@ff5e0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-crl-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_crl";
+                        reg = <0x0 0xff5e0000 0x0 0x300000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_crl_0";
+                        phandle = <0x5a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_crp_0: versal_cips_0_pspmc_0_psv_crp_0@f1260000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-crp-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_crp";
+                        reg = <0x0 0xf1260000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_crp_0";
+                        phandle = <0x36>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_0: versal_cips_0_pspmc_0_psv_fpd_afi_0@fd360000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi";
+                        reg = <0x0 0xfd360000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_0";
+                        phandle = <0x44>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_2: versal_cips_0_pspmc_0_psv_fpd_afi_2@fd380000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi";
+                        reg = <0x0 0xfd380000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_2";
+                        phandle = <0x45>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_0: versal_cips_0_pspmc_0_psv_fpd_afi_mem_0@a4000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-mem-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi_mem";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xa4000000 0x0 0xc000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_mem_0";
+                        phandle = <0x12e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_2: versal_cips_0_pspmc_0_psv_fpd_afi_mem_2@b0000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-mem-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi_mem";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xb0000000 0x0 0x10000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_mem_2";
+                        phandle = <0x12f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_cci_0: versal_cips_0_pspmc_0_psv_fpd_cci_0@fd5e0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-cci-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_cci";
+                        reg = <0x0 0xfd5e0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_cci_0";
+                        phandle = <0x48>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_gpv_0: versal_cips_0_pspmc_0_psv_fpd_gpv_0@fd700000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-gpv-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_gpv";
+                        reg = <0x0 0xfd700000 0x0 0x100000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_gpv_0";
+                        phandle = <0x4c>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_slcr_0: versal_cips_0_pspmc_0_psv_fpd_slcr_0@fd610000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_slcr";
+                        reg = <0x0 0xfd610000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_slcr_0";
+                        phandle = <0x4a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0: versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0@fd690000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-slcr-secure-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_slcr_secure";
+                        reg = <0x0 0xfd690000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0";
+                        phandle = <0x4b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_smmu_0: versal_cips_0_pspmc_0_psv_fpd_smmu_0@fd5f0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-smmu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_smmu";
+                        reg = <0x0 0xfd5f0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_smmu_0";
+                        phandle = <0x49>;
+                };
+
+                versal_cips_0_pspmc_0_psv_ipi_buffer: versal_cips_0_pspmc_0_psv_ipi_buffer@ff3f0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-ipi-buffer-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_ipi_buffer";
+                        reg = <0x0 0xff3f0000 0x0 0x1000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_buffer";
+                        phandle = <0x130>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_afi_0: versal_cips_0_pspmc_0_psv_lpd_afi_0@ff9b0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-afi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_afi";
+                        reg = <0x0 0xff9b0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_afi_0";
+                        phandle = <0x5f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_afi_mem_0: versal_cips_0_pspmc_0_psv_lpd_afi_mem_0@80000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-afi-mem-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_afi_mem";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0x80000000 0x0 0x20000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_afi_mem_0";
+                        phandle = <0x131>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0: versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0@ff0a0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-iou-secure-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_iou_secure_slcr";
+                        reg = <0x0 0xff0a0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0";
+                        phandle = <0x52>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0: versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0@ff080000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-iou-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_iou_slcr";
+                        reg = <0x0 0xff080000 0x0 0x20000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0";
+                        phandle = <0x51>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_slcr_0: versal_cips_0_pspmc_0_psv_lpd_slcr_0@ff410000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_slcr";
+                        reg = <0x0 0xff410000 0x0 0x100000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_slcr_0";
+                        phandle = <0x58>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0: versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0@ff510000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-slcr-secure-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_slcr_secure";
+                        reg = <0x0 0xff510000 0x0 0x40000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0";
+                        phandle = <0x59>;
+                };
+
+                versal_cips_0_pspmc_0_psv_noc_pcie_0: versal_cips_0_pspmc_0_psv_noc_pcie_0@e0000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-noc-pcie-0-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_noc_pcie_0";
+                        reg = <0x0 0xe0000000 0x0 0x10000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_noc_pcie_0";
+                        phandle = <0xd>;
+                };
+
+                versal_cips_0_pspmc_0_psv_noc_pcie_1: versal_cips_0_pspmc_0_psv_noc_pcie_1@600000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-noc-pcie-1-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_noc_pcie_1";
+                        reg = <0x6 0x0 0x2 0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_noc_pcie_1";
+                        phandle = <0x6d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_noc_pcie_2: versal_cips_0_pspmc_0_psv_noc_pcie_2@8000000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-noc-pcie-2-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_noc_pcie_2";
+                        reg = <0x80 0x0 0x40 0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_noc_pcie_2";
+                        phandle = <0x6e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_ocm_ctrl: versal_cips_0_pspmc_0_psv_ocm_ctrl@ff960000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-ocm-1.0";
+                        status = "okay";
+                        power-domains = <&versal_firmware 0x18314007>;
+                        xlnx,ip-name = "psv_ocm";
+                        reg = <0x0 0xff960000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ocm_ctrl";
+                        phandle = <0x5b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_aes: versal_cips_0_pspmc_0_psv_pmc_aes@f11e0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-aes-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_aes";
+                        reg = <0x0 0xf11e0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_aes";
+                        phandle = <0x2e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl: versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl@f11f0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-bbram-ctrl-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_bbram_ctrl";
+                        reg = <0x0 0xf11f0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl";
+                        phandle = <0x2f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0: versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0@f12d0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-cfi-cframe-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_cfi_cframe";
+                        reg = <0x0 0xf12d0000 0x0 0x1000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0";
+                        phandle = <0x3a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0: versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0@f12b0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-cfu-apb-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_cfu_apb";
+                        reg = <0x0 0xf12b0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0";
+                        phandle = <0x39>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_efuse_cache: versal_cips_0_pspmc_0_psv_pmc_efuse_cache@f1250000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-efuse-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_efuse_cache";
+                        reg = <0x0 0xf1250000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_efuse_cache";
+                        phandle = <0x35>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl: versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl@f1240000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-efuse-ctrl-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_efuse_ctrl";
+                        reg = <0x0 0xf1240000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl";
+                        phandle = <0x34>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_global_0: versal_cips_0_pspmc_0_psv_pmc_global_0@f1110000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-global-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_global";
+                        reg = <0x0 0xf1110000 0x0 0x50000>;
+                        xlnx,npi-scan = <0x0>;
+                        xlnx,event-log = <0x0>;
+                        xlnx,cram-scan = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_global_0";
+                        phandle = <0x2b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0: versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0@f0310000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-ppu1-mdm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_ppu1_mdm";
+                        reg = <0x0 0xf0310000 0x0 0x8000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0";
+                        phandle = <0xe>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram: versal_cips_0_pspmc_0_psv_pmc_ram@f2000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-ram-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_ram";
+                        reg = <0x0 0xf2000000 0x0 0x20000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram";
+                        phandle = <0x132>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr: versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr@f0240000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,ram-data-cntlr-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xffffffff 0xffffe000>;
+                        xlnx,mask1 = <0xffffffff 0xffffe000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "ram_data_cntlr";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xf0240000 0x0 0x20000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr";
+                        phandle = <0x7b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr: versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr@f0200000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,ram-instr-cntlr-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xfffe0000>;
+                        xlnx,mask1 = <0xfffe0000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "ram_instr_cntlr";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xf0200000 0x0 0x40000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr";
+                        phandle = <0x7a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram_npi: versal_cips_0_pspmc_0_psv_pmc_ram_npi@f6000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-ram-npi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_ram_npi";
+                        reg = <0x0 0xf6000000 0x0 0x2000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram_npi";
+                        phandle = <0x3f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_rsa: versal_cips_0_pspmc_0_psv_pmc_rsa@f1200000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-rsa-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_rsa";
+                        reg = <0x0 0xf1200000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_rsa";
+                        phandle = <0x30>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_sha: versal_cips_0_pspmc_0_psv_pmc_sha@f1210000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-sha-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_sha";
+                        reg = <0x0 0xf1210000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_sha";
+                        phandle = <0x31>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot: versal_cips_0_pspmc_0_psv_pmc_slave_boot@f1220000 {
+                        xlnx,rable = <0x0>;
+                        xlnx,device-id = <0x0>;
+                        compatible = "xlnx,psv-pmc-slave-boot-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_slave_boot";
+                        reg = <0x0 0xf1220000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_slave_boot";
+                        phandle = <0x32>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream: versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream@f2100000 {
+                        xlnx,rable = <0x0>;
+                        xlnx,device-id = <0x0>;
+                        compatible = "xlnx,psv-pmc-slave-boot-stream-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_slave_boot_stream";
+                        reg = <0x0 0xf2100000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream";
+                        phandle = <0x3e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0: versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0@f0083000 {
+                        compatible = "xlnx,tmr-inject-1.0";
+                        xlnx,cpu-id = <0x1>;
+                        xlnx,edk-special = "tmr_inject";
+                        xlnx,mask = <0x84000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "tmr_inject";
+                        reg = <0x0 0xf0083000 0x0 0x1000>;
+                        xlnx,magic = <0x27>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        status = "okay";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x79>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0: versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0@f0283000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,use-debug-disable = <0x0>;
+                        xlnx,sem-interface-type = <0x1>;
+                        compatible = "xlnx,tmr-manager-1.0";
+                        xlnx,magic1 = <0x0>;
+                        xlnx,tmr = <0x1>;
+                        xlnx,magic2 = <0x0>;
+                        xlnx,brk-delay-rst-value = <0x0>;
+                        xlnx,mask = <0x83000>;
+                        xlnx,sem-heartbeat-watchdog-width = <0xa>;
+                        xlnx,rable = <0x0>;
+                        xlnx,watchdog-width = <0x1e>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,ue-width = <0x3>;
+                        xlnx,ip-name = "tmr_manager";
+                        xlnx,async-ff = <0x2>;
+                        xlnx,ue-is-fatal = <0x0>;
+                        xlnx,sem-heartbeat-watchdog = <0x0>;
+                        reg = <0x0 0xf0283000 0x0 0x1000>;
+                        xlnx,brk-delay-width = <0x0>;
+                        xlnx,watchdog = <0x0>;
+                        xlnx,sem-interface = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mask-rst-value = <0xffffffff 0xffffffff>;
+                        xlnx,comparators-mask = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,test-comparator = <0x0>;
+                        xlnx,strict-miscompare = <0x0>;
+                        status = "okay";
+                        xlnx,no-of-comparators = <0x1>;
+                        xlnx,sem-async = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x7d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_trng: versal_cips_0_pspmc_0_psv_pmc_trng@f1230000 {
+                        xlnx,rable = <0x0>;
+                        xlnx,device-id = <0x0>;
+                        compatible = "xlnx,psv-pmc-trng-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_trng";
+                        reg = <0x0 0xf1230000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_trng";
+                        phandle = <0x33>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_global_reg: versal_cips_0_pspmc_0_psv_psm_global_reg@ffc90000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-psm-global-reg-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_psm_global_reg";
+                        reg = <0x0 0xffc90000 0x0 0xf000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_global_reg";
+                        phandle = <0x69>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_iomodule_0: versal_cips_0_pspmc_0_psv_psm_iomodule_0@ffc80000 {
+                        xlnx,gpo4-size = <0x20>;
+                        xlnx,tmr = <0x0>;
+                        xlnx,pit1-readable = <0x1>;
+                        xlnx,mask = <0xffff8000>;
+                        xlnx,pit-size = <0x20 0x20 0x20 0x20>;
+                        xlnx,pit2-prescaler = <0x0>;
+                        xlnx,gpi3-interrupt = <0x0>;
+                        xlnx,intc-level-edge = <0x7fff>;
+                        xlnx,rable = <0x0>;
+                        xlnx,intc-positive = <0xffff>;
+                        xlnx,ip-name = "iomodule";
+                        xlnx,gpo1-size = <0x3>;
+                        xlnx,max-intr-size = <0x20>;
+                        xlnx,pit3-size = <0x20>;
+                        xlnx,fit3-interrupt = <0x0>;
+                        reg = <0x0 0xffc80000 0x0 0x8000>;
+                        xlnx,fit1-no-clocks = <0x1848>;
+                        xlnx,gpi2-size = <0x20>;
+                        xlnx,pit2-readable = <0x1>;
+                        xlnx,intc-irq-connection = <0x0>;
+                        xlnx,uart-tx-interrupt = <0x1>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,pit2-interrupt = <0x1>;
+                        xlnx,intc-base-vectors = <0xffc00000>;
+                        compatible = "xlnx,iomodule-1.0", "xlnx,iomodule-3.1";
+                        xlnx,gpo4-init = <0x0>;
+                        xlnx,pit3-readable = <0x1>;
+                        xlnx,pit3-prescaler = <0x9>;
+                        xlnx,gpi4-interrupt = <0x0>;
+                        xlnx,gpo1-init = <0x0>;
+                        xlnx,use-io-bus = <0x0>;
+                        xlnx,use-gpo1 = <0x1>;
+                        xlnx,uart-baudrate = <0x1c200>;
+                        xlnx,fit4-interrupt = <0x0>;
+                        xlnx,gpo3-size = <0x20>;
+                        xlnx,use-gpo2 = <0x0>;
+                        xlnx,uart-data-bits = <0x8>;
+                        xlnx,pit-prescaler = <0x9 0x0 0x9 0x0>;
+                        xlnx,gpio1-board-interface = "Custom";
+                        xlnx,use-gpo3 = <0x0>;
+                        xlnx,fit2-no-clocks = <0x1848>;
+                        xlnx,options = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,use-gpo4 = <0x0>;
+                        xlnx,gpi4-size = <0x20>;
+                        xlnx,gpio3-board-interface = "Custom";
+                        xlnx,uart-rx-interrupt = <0x1>;
+                        xlnx,uart-error-interrupt = <0x1>;
+                        xlnx,gpio4-board-interface = "Custom";
+                        xlnx,pit4-readable = <0x1>;
+                        status = "okay";
+                        xlnx,intc-use-irq-out = <0x0>;
+                        xlnx,clock-freq = <0x5f5e100>;
+                        xlnx,gpo-init = <0x0 0x0 0x0 0x0>;
+                        xlnx,use-board-flow;
+                        xlnx,pit2-size = <0x20>;
+                        xlnx,intc-intr-size = <0x10>;
+                        xlnx,intc-use-ext-intr = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_iomodule_0";
+                        xlnx,gpi1-size = <0x20>;
+                        xlnx,edk-special = "INTR_CTRL";
+                        xlnx,pit3-interrupt = <0x1>;
+                        xlnx,intc-has-fast = <0x0>;
+                        xlnx,pit-used = <0x1 0x1 0x1 0x1>;
+                        xlnx,use-gpi1 = <0x0>;
+                        xlnx,gpi1-interrupt = <0x0>;
+                        xlnx,use-gpi2 = <0x0>;
+                        xlnx,use-gpi3 = <0x0>;
+                        xlnx,use-gpi4 = <0x0>;
+                        xlnx,fit1-interrupt = <0x0>;
+                        xlnx,pit4-prescaler = <0x0>;
+                        xlnx,gpo3-init = <0x0>;
+                        xlnx,intc-addr-width = <0x20>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,fit3-no-clocks = <0x1848>;
+                        xlnx,use-uart-rx = <0x1>;
+                        xlnx,instance = "iomodule_0";
+                        xlnx,pit-mask = <0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+                        xlnx,uart-prog-baudrate = <0x1>;
+                        xlnx,use-pit1 = <0x1>;
+                        xlnx,gpo2-size = <0x20>;
+                        xlnx,use-pit2 = <0x1>;
+                        xlnx,pit4-size = <0x20>;
+                        xlnx,pit-readable = <0x1 0x1 0x1 0x1>;
+                        xlnx,use-pit3 = <0x1>;
+                        xlnx,use-pit4 = <0x1>;
+                        xlnx,pit4-interrupt = <0x1>;
+                        xlnx,gpi3-size = <0x20>;
+                        xlnx,intc-async-intr = <0xffff>;
+                        xlnx,pit1-prescaler = <0x9>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,gpi2-interrupt = <0x0>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,use-fit1 = <0x0>;
+                        xlnx,pit1-size = <0x20>;
+                        xlnx,intc-num-sync-ff = <0x2>;
+                        xlnx,uart-board-interface = "rs232_uart";
+                        xlnx,use-fit2 = <0x0>;
+                        xlnx,fit2-interrupt = <0x0>;
+                        xlnx,use-fit3 = <0x0>;
+                        xlnx,use-fit4 = <0x0>;
+                        xlnx,uart-use-parity = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,fit4-no-clocks = <0x1848>;
+                        xlnx,uart-odd-parity = <0x0>;
+                        xlnx,freq = <0x5f5e100>;
+                        xlnx,use-uart-tx = <0x1>;
+                        xlnx,pit1-interrupt = <0x1>;
+                        xlnx,gpo2-init = <0x0>;
+                        xlnx,io-mask = <0xfffe0000>;
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x81>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr: versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr@ffc20000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,PSM-PPU-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xffffffff 0xffffe000>;
+                        xlnx,mask1 = <0xffffffff 0xffffe000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "PSM_PPU";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xffc20000 0x0 0x20000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr";
+                        phandle = <0x80>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr: versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr@ffc00000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,ram-instr-cntlr-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xffffffff 0xfffe0000>;
+                        xlnx,mask1 = <0xffffffff 0xfffe0000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "ram_instr_cntlr";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xffc00000 0x0 0x20000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr";
+                        phandle = <0x7f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_tmr_inject_0: versal_cips_0_pspmc_0_psv_psm_tmr_inject_0@ffcd0000 {
+                        compatible = "xlnx,tmr-inject-1.0";
+                        xlnx,cpu-id = <0x1>;
+                        xlnx,edk-special = "tmr_inject";
+                        xlnx,mask = <0x50000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "tmr_inject";
+                        reg = <0x0 0xffcd0000 0x0 0x10000>;
+                        xlnx,magic = <0x27>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        status = "okay";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_tmr_inject_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x83>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_tmr_manager_0: versal_cips_0_pspmc_0_psv_psm_tmr_manager_0@ffcc0000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,use-debug-disable = <0x0>;
+                        xlnx,sem-interface-type = <0x1>;
+                        compatible = "xlnx,tmr-manager-1.0";
+                        xlnx,magic1 = <0x0>;
+                        xlnx,tmr = <0x1>;
+                        xlnx,magic2 = <0x0>;
+                        xlnx,brk-delay-rst-value = <0x0>;
+                        xlnx,mask = <0x50000>;
+                        xlnx,sem-heartbeat-watchdog-width = <0xa>;
+                        xlnx,rable = <0x0>;
+                        xlnx,watchdog-width = <0x1e>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,ue-width = <0x3>;
+                        xlnx,ip-name = "tmr_manager";
+                        xlnx,async-ff = <0x2>;
+                        xlnx,ue-is-fatal = <0x0>;
+                        xlnx,sem-heartbeat-watchdog = <0x0>;
+                        reg = <0x0 0xffcc0000 0x0 0x10000>;
+                        xlnx,brk-delay-width = <0x0>;
+                        xlnx,watchdog = <0x0>;
+                        xlnx,sem-interface = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mask-rst-value = <0xffffffff 0xffffffff>;
+                        xlnx,comparators-mask = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,test-comparator = <0x0>;
+                        xlnx,strict-miscompare = <0x0>;
+                        status = "okay";
+                        xlnx,no-of-comparators = <0x1>;
+                        xlnx,sem-async = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_tmr_manager_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x82>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_atcm: versal_cips_0_pspmc_0_psv_r5_0_atcm@0 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x0 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_atcm";
+                        phandle = <0x85>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep: versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep@ffe10000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-atcm-lockstep-1.0", "mmio-sram";
+                        status = "okay";
+                        power-domains = <&versal_firmware 0x1831800b>;
+                        xlnx,ip-name = "psv_r5_0_atcm_lockstep";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xffe10000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep";
+                        phandle = <0x133>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_btcm: versal_cips_0_pspmc_0_psv_r5_0_btcm@20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_btcm";
+                        phandle = <0x87>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep: versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep@ffe30000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-btcm-lockstep-1.0", "mmio-sram";
+                        status = "okay";
+                        power-domains = <&versal_firmware 0x1831800c>;
+                        xlnx,ip-name = "psv_r5_0_btcm_lockstep";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xffe30000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep";
+                        phandle = <0x134>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_data_cache: versal_cips_0_pspmc_0_psv_r5_0_data_cache@ffe50000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-data-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_0_data_cache";
+                        reg = <0x0 0xffe50000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_data_cache";
+                        phandle = <0x8a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_instruction_cache: versal_cips_0_pspmc_0_psv_r5_0_instruction_cache@ffe40000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-instruction-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_0_instruction_cache";
+                        reg = <0x0 0xffe40000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_instruction_cache";
+                        phandle = <0x89>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_atcm: versal_cips_0_pspmc_0_psv_r5_1_atcm@0 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x0 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_atcm";
+                        phandle = <0x8d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_btcm: versal_cips_0_pspmc_0_psv_r5_1_btcm@20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_btcm";
+                        phandle = <0x8e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_data_cache: versal_cips_0_pspmc_0_psv_r5_1_data_cache@ffed0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-1-data-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_1_data_cache";
+                        reg = <0x0 0xffed0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_data_cache";
+                        phandle = <0x8c>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_instruction_cache: versal_cips_0_pspmc_0_psv_r5_1_instruction_cache@ffec0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-1-instruction-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_1_instruction_cache";
+                        reg = <0x0 0xffec0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_instruction_cache";
+                        phandle = <0x8b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_tcm_ram_0: versal_cips_0_pspmc_0_psv_r5_tcm_ram_0@0 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x0 0x0 0x40000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_tcm_ram_0";
+                        phandle = <0x86>;
+                };
+
+                versal_cips_0_pspmc_0_psv_rpu_0: versal_cips_0_pspmc_0_psv_rpu_0@ff9a0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-rpu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_rpu";
+                        reg = <0x0 0xff9a0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_rpu_0";
+                        phandle = <0x5e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_scntr_0: versal_cips_0_pspmc_0_psv_scntr_0@ff130000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-scntr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_scntr";
+                        reg = <0x0 0xff130000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_scntr_0";
+                        phandle = <0x56>;
+                };
+
+                versal_cips_0_pspmc_0_psv_scntrs_0: versal_cips_0_pspmc_0_psv_scntrs_0@ff140000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-scntrs-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_scntrs";
+                        reg = <0x0 0xff140000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_scntrs_0";
+                        phandle = <0x57>;
+                };
+        };
+
+        psv_r5_0_atcm_global: psv_r5_0_atcm_global@ffe00000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800b>;
+                reg = <0x0 0xffe00000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,is-hierarchy;
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_atcm_global";
+                phandle = <0x6a>;
+        };
+
+        psv_r5_0_btcm_global: psv_r5_0_btcm_global@ffe20000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800c>;
+                reg = <0x0 0xffe20000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,is-hierarchy;
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_btcm_global";
+                phandle = <0x135>;
+        };
+
+        psv_r5_1_atcm_global: psv_r5_1_atcm_global@ffe90000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800d>;
+                reg = <0x0 0xffe90000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_atcm_global";
+                phandle = <0x6b>;
+        };
+
+        psv_r5_1_btcm_global: psv_r5_1_btcm_global@ffeb0000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800e>;
+                reg = <0x0 0xffeb0000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_btcm_global";
+                phandle = <0x6c>;
+        };
+
+        amba_xppu: indirect-bus@1 {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0x136>;
+
+                lpd_xppu: xppu@ff990000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xff990000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_lpd_xppu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_xppu_0";
+                        phandle = <0x5d>;
+                };
+
+                pmc_xppu: xppu@f1310000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf1310000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_xppu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_xppu_0";
+                        phandle = <0x3d>;
+                };
+
+                pmc_xppu_npi: xppu@f1300000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf1300000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_xppu_npi";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_xppu_npi_0";
+                        phandle = <0x3c>;
+                };
+        };
+
+        amba_xmpu: indirect-bus@2 {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0x137>;
+
+                fpd_xmpu: xmpu@fd390000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xfd390000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_fpd_slave_xmpu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_slave_xmpu_0";
+                        phandle = <0x46>;
+                };
+
+                pmc_xmpu: xmpu@f12f0000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf12f0000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_xmpu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_xmpu_0";
+                        phandle = <0x3b>;
+                };
+
+                ocm_xmpu: xmpu@ff980000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xff980000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_ocm_xmpu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ocm_xmpu_0";
+                        phandle = <0x5c>;
+                };
+
+                ddrmc_xmpu_0: xmpu@f6080000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6080000 0x0 0x1000>;
+                        status = "okay";
+                        phandle = <0x138>;
+                };
+
+                ddrmc_xmpu_1: xmpu@f6220000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6220000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x139>;
+                };
+
+                ddrmc_xmpu_2: xmpu@f6390000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6390000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x13a>;
+                };
+
+                ddrmc_xmpu_3: xmpu@f6500000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6500000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x13b>;
+                };
+        };
+
+        pl_alt_ref_clk: pl_alt_ref_clk {
+                bootph-all;
+                compatible = "fixed-clock";
+                #clock-cells = <0x0>;
+                clock-frequency = <0x1fca055>;
+                phandle = <0x9b>;
+        };
+
+        ref_clk: ref_clk {
+                bootph-all;
+                compatible = "fixed-clock";
+                #clock-cells = <0x0>;
+                clock-frequency = <0x1fca055>;
+                phandle = <0x9a>;
+        };
+
+        can0_clk: can0_clk {
+                #clock-cells = <0x0>;
+                compatible = "fixed-factor-clock";
+                clocks = <&versal_clk 0x60>;
+                clock-div = <0x2>;
+                clock-mult = <0x1>;
+                phandle = <0x92>;
+        };
+
+        can1_clk: can1_clk {
+                #clock-cells = <0x0>;
+                compatible = "fixed-factor-clock";
+                clocks = <&versal_clk 0x61>;
+                clock-div = <0x2>;
+                clock-mult = <0x1>;
+                phandle = <0x93>;
+        };
+
+        firmware {
+
+                versal_firmware: versal-firmware {
+                        compatible = "xlnx,versal-firmware";
+                        interrupt-parent = <&imux>;
+                        bootph-all;
+                        method = "smc";
+                        #power-domain-cells = <0x1>;
+                        phandle = <0x75>;
+
+                        versal_clk: clock-controller {
+                                bootph-all;
+                                #clock-cells = <0x1>;
+                                compatible = "xlnx,versal-clk";
+                                clocks = <&ref_clk>,
+                                 <&pl_alt_ref_clk>;
+                                clock-names = "ref_clk", "pl_alt_ref_clk";
+                                phandle = <0x76>;
+                        };
+
+                        zynqmp_power: zynqmp-power {
+                                compatible = "xlnx,zynqmp-power";
+                                phandle = <0x13c>;
+                        };
+
+                        versal_reset: reset-controller {
+                                compatible = "xlnx,versal-reset";
+                                #reset-cells = <0x1>;
+                                phandle = <0x97>;
+                        };
+
+                        pinctrl0: pinctrl {
+                                compatible = "xlnx,versal-pinctrl";
+                                phandle = <0x13d>;
+                        };
+
+                        versal_sec_cfg: versal-sec-cfg {
+                                compatible = "xlnx,versal-sec-cfg";
+                                #address-cells = <0x1>;
+                                #size-cells = <0x1>;
+                                phandle = <0x13e>;
+
+                                bbram_zeroize: bbram-zeroize@4 {
+                                        reg = <0x4 0x4>;
+                                        phandle = <0x13f>;
+                                };
+
+                                bbram_key: bbram-key@10 {
+                                        reg = <0x10 0x20>;
+                                        phandle = <0x140>;
+                                };
+
+                                bbram_usr: bbram-usr@30 {
+                                        reg = <0x30 0x4>;
+                                        phandle = <0x141>;
+                                };
+
+                                bbram_lock: bbram-lock@48 {
+                                        reg = <0x48 0x4>;
+                                        phandle = <0x142>;
+                                };
+
+                                user_key0: user-key@110 {
+                                        reg = <0x110 0x20>;
+                                        phandle = <0x143>;
+                                };
+
+                                user_key1: user-key@130 {
+                                        reg = <0x130 0x20>;
+                                        phandle = <0x144>;
+                                };
+
+                                user_key2: user-key@150 {
+                                        reg = <0x150 0x20>;
+                                        phandle = <0x145>;
+                                };
+
+                                user_key3: user-key@170 {
+                                        reg = <0x170 0x20>;
+                                        phandle = <0x146>;
+                                };
+
+                                user_key4: user-key@190 {
+                                        reg = <0x190 0x20>;
+                                        phandle = <0x147>;
+                                };
+
+                                user_key5: user-key@1b0 {
+                                        reg = <0x1b0 0x20>;
+                                        phandle = <0x148>;
+                                };
+
+                                user_key6: user-key@1d0 {
+                                        reg = <0x1d0 0x20>;
+                                        phandle = <0x149>;
+                                };
+
+                                user_key7: user-key@1f0 {
+                                        reg = <0x1f0 0x20>;
+                                        phandle = <0x14a>;
+                                };
+                        };
+                };
+        };
+
+        amba_pl: amba_pl {
+                ranges;
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                firmware-name = "qdma-example-kula-vmk180-20260526.pdi";
+                phandle = <0x14b>;
+
+                misc_clk_0: misc_clk_0 {
+                        compatible = "fixed-clock";
+                        clock-frequency = <0xee6b280>;
+                        #clock-cells = <0x0>;
+                        phandle = <0x9c>;
+                };
+
+                axi_bram_ctrl_0: axi_bram_ctrl@0 {
+                        xlnx,protocol = "AXI4LITE";
+                        xlnx,edk-special = "BRAM_CTRL";
+                        compatible = "xlnx,axi-bram-ctrl-4.1";
+                        xlnx,ecc-onoff-reset-value = <0x0>;
+                        xlnx,ecc-type = <0x0>;
+                        xlnx,rd-cmd-optimization = <0x0>;
+                        xlnx,memory-depth = <0x400>;
+                        xlnx,use-ecc = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,fault-inject = <0x0>;
+                        xlnx,ip-name = "axi_bram_ctrl";
+                        reg = <0x0 0x0 0x0 0x1000>;
+                        xlnx,bmg-instance = "EXTERNAL";
+                        clocks = <&misc_clk_0>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,read-latency = <0x1>;
+                        xlnx,id-width = <0x0>;
+                        xlnx,s-axi-supports-narrow-burst = <0x0>;
+                        xlnx,supports-narrow-burst = <0x0>;
+                        xlnx,single-port-bram = <0x1>;
+                        xlnx,ecc = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        status = "okay";
+                        clock-names = "s_axi_aclk";
+                        xlnx,data-width = <0x20>;
+                        xlnx,bram-addr-width = <0xa>;
+                        xlnx,bram-inst-mode = "EXTERNAL";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,mem-depth = <0x400>;
+                        xlnx,s-axi-id-width = <0x1>;
+                        xlnx,name = "axi_bram_ctrl_0";
+                        phandle = <0x14c>;
+                };
+
+                axi_gpio_0: gpio@20200000000 {
+                        #interrupt-cells = <0x2>;
+                        interrupts = <0x0 0x5d 0x4>;
+                        xlnx,gpio-board-interface = "Custom";
+                        compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+                        xlnx,all-outputs = <0x0>;
+                        #gpio-cells = <0x2>;
+                        xlnx,gpio-width = <0x20>;
+                        interrupt-parent = <&imux>;
+                        xlnx,rable = <0x0>;
+                        xlnx,dout-default = <0x0>;
+                        xlnx,is-dual = <0x1>;
+                        xlnx,ip-name = "axi_gpio";
+                        xlnx,tri-default-2 = <0xffffffff>;
+                        reg = <0x202 0x0 0x0 0x10000>;
+                        xlnx,all-inputs-2 = <0x0>;
+                        clocks = <&misc_clk_0>;
+                        xlnx,all-outputs-2 = <0x1>;
+                        gpio-controller;
+                        xlnx,interrupt-present = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,dout-default-2 = <0x0>;
+                        status = "okay";
+                        xlnx,gpio2-width = <0x20>;
+                        clock-names = "s_axi_aclk";
+                        interrupt-controller;
+                        interrupt-names = "ip2intc_irpt";
+                        xlnx,tri-default = <0xffffffff>;
+                        xlnx,name = "axi_gpio_0";
+                        xlnx,all-inputs = <0x1>;
+                        phandle = <0x70>;
+                };
+
+                axi_gpio_1: gpio@20200010000 {
+                        #interrupt-cells = <0x2>;
+                        xlnx,gpio-board-interface = "Custom";
+                        compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+                        xlnx,all-outputs = <0x0>;
+                        #gpio-cells = <0x2>;
+                        xlnx,gpio-width = <0x20>;
+                        xlnx,rable = <0x0>;
+                        xlnx,dout-default = <0x0>;
+                        xlnx,is-dual = <0x1>;
+                        xlnx,ip-name = "axi_gpio";
+                        xlnx,tri-default-2 = <0xffffffff>;
+                        reg = <0x202 0x10000 0x0 0x10000>;
+                        xlnx,all-inputs-2 = <0x0>;
+                        clocks = <&misc_clk_0>;
+                        xlnx,all-outputs-2 = <0x1>;
+                        gpio-controller;
+                        xlnx,interrupt-present = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,dout-default-2 = <0x0>;
+                        status = "okay";
+                        xlnx,gpio2-width = <0x20>;
+                        clock-names = "s_axi_aclk";
+                        interrupt-controller;
+                        xlnx,tri-default = <0xffffffff>;
+                        xlnx,name = "axi_gpio_1";
+                        xlnx,all-inputs = <0x1>;
+                        phandle = <0x71>;
+                };
+
+                mailbox_0: mailbox@20180000000 {
+                        interrupts = <0x0 0x5c 0x4>;
+                        xlnx,s1-axi-aclk-freq-mhz = <0xfa>;
+                        compatible = "xlnx,mailbox-2.1";
+                        xlnx,interconnect-port-0 = <0x2>;
+                        xlnx,interconnect-port-1 = <0x2>;
+                        interrupt-parent = <&imux>;
+                        xlnx,rable = <0x0>;
+                        xlnx,mailbox-depth = <0x40>;
+                        xlnx,s1-axi-data-width = <0x20>;
+                        xlnx,s0-axi-addr-width = <0x20>;
+                        xlnx,ip-name = "mailbox";
+                        reg = <0x201 0x80000000 0x0 0x10000 0x201 0x80010000 0x0 0x10000>;
+                        xlnx,async-clks = <0x0>;
+                        xlnx,impl-style = <0x0>;
+                        clocks = <&misc_clk_0>,
+                         <&misc_clk_0>;
+                        xlnx,read-clock-period-0 = <0x0>;
+                        xlnx,read-clock-period-1 = <0x0>;
+                        xlnx,num-sync-ff = <0x2>;
+                        xlnx,async-interrupts = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,enable-bus-error = <0x0>;
+                        xlnx,s0-axi-data-width = <0x20>;
+                        status = "okay";
+                        xlnx,ext-reset-high = <0x1>;
+                        clock-names = "S0_AXI_ACLK", "S1_AXI_ACLK";
+                        interrupt-names = "Interrupt_0";
+                        xlnx,s1-axi-addr-width = <0x20>;
+                        xlnx,s0-axi-aclk-freq-mhz = <0xfa>;
+                        xlnx,name = "mailbox_0";
+                        phandle = <0x6f>;
+                };
+
+                pcie_qdma_mailbox_0: pcie_qdma_mailbox@20800000000 {
+                        xlnx,num-vfs-pf3 = <0x3c>;
+                        compatible = "xlnx,pcie-qdma-mailbox-1.0";
+                        xlnx,patch-revision = <0x20140001>;
+                        xlnx,rtl-revision = <0x1fd31000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,h10-device = <0x0>;
+                        xlnx,ip-name = "pcie_qdma_mailbox";
+                        xlnx,total-fnc = <0x100>;
+                        reg = <0x208 0x0 0x0 0x80000000>;
+                        clocks = <&misc_clk_0>,
+                         <&misc_clk_0>;
+                        xlnx,max-pf = <0x4>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mailbox-opt;
+                        xlnx,versal;
+                        status = "okay";
+                        xlnx,num-pfs = <0x4>;
+                        clock-names = "axi_aclk", "ip_clk";
+                        xlnx,num-vfs-pf0 = <0x40>;
+                        xlnx,num-vfs-pf1 = <0x40>;
+                        xlnx,vf-4kq = <0x0>;
+                        xlnx,num-vfs-pf2 = <0x40>;
+                        xlnx,name = "pcie_qdma_mailbox_0";
+                        phandle = <0x72>;
+                };
+        };
+
+        axi_noc_0_ddr_memory: memory@00000000 {
+                compatible = "xlnx,axi-noc-1.1";
+                xlnx,ip-name = "axi_noc";
+                device_type = "memory";
+                reg = <0x0 0x0 0x0 0x80000000>;
+                memory_type = "memory";
+                phandle = <0x3>;
+        };
+
+        versal_cips_0_pspmc_0_psv_ocm_ram_0_memory: memory@FFFC0000 {
+                compatible = "xlnx,psv-ocm-ram-0-1.0", "mmio-sram";
+                xlnx,ip-name = "psv_ocm_ram_0";
+                device_type = "memory";
+                memory_type = "memory";
+                reg = <0x0 0xfffc0000 0x0 0x40000>;
+                phandle = <0xc>;
+        };
+
+        chosen {
+                stdout-path = "serial0:115200";
+                bootargs = "console=ttyAMA0 earlycon=pl011,mmio32,0xFF000000,115200n8 clk_ignore_unused";
+        };
+
+        aliases {
+                serial0 = "/axi/serial@ff000000";
+                spi0 = "/axi/spi@f1030000";
+                serial1 = "/axi/coresight@f0800000";
+                i2c0 = "/axi/i2c@ff020000";
+                ethernet0 = "/axi/ethernet@ff0c0000";
+                serial2 = "/dcc";
+                ethernet1 = "/axi/ethernet@ff0d0000";
+                i2c1 = "/axi/i2c@ff030000";
+                mmc0 = "/axi/mmc@f1050000";
+                usb0 = "/axi/usb@ff9d0000";
+                rtc0 = "/axi/rtc@f12a0000";
+        };
+
+        __symbols__ {
+                cpus_a72 = "/cpus-a72@0";
+                psv_cortexa72_0 = "/cpus-a72@0/cpu@0";
+                psv_cortexa72_1 = "/cpus-a72@0/cpu@1";
+                CPU_SLEEP_0 = "/cpus-a72@0/idle-states/cpu-sleep-0";
+                cpus_microblaze_0 = "/cpus_microblaze@0";
+                psv_pmc_0 = "/cpus_microblaze@0/cpu@0";
+                cpus_microblaze_1 = "/cpus_microblaze@1";
+                psv_psm_0 = "/cpus_microblaze@1/cpu@0";
+                cpus_r5_0 = "/cpus-r5@0";
+                psv_cortexr5_0 = "/cpus-r5@0/cpu@0";
+                cpus_r5_1 = "/cpus-r5@1";
+                psv_cortexr5_1 = "/cpus-r5@1/cpu@1";
+                cpu_opp_table = "/opp-table-cpu";
+                dcc = "/dcc";
+                fpga = "/fpga-region";
+                psci = "/psci";
+                timer = "/timer";
+                versal_fpga = "/versal-fpga";
+                sensor0 = "/versal-thermal-sensor";
+                versal_thermal = "/thermal-zones/versal-thermal";
+                temp_alert = "/thermal-zones/versal-thermal/trips/temp-alert";
+                ot_crit = "/thermal-zones/versal-thermal/trips/ot-crit";
+                amba_apu = "/apu-bus";
+                gic_a72 = "/apu-bus/interrupt-controller@f9000000";
+                gic_its = "/apu-bus/interrupt-controller@f9000000/msi-controller@f9020000";
+                amba_rpu = "/rpu-bus";
+                gic_r5 = "/rpu-bus/interrupt-controller@f9000000";
+                amba = "/axi";
+                imux = "/axi/interrupt-multiplex";
+                can0 = "/axi/can@ff060000";
+                can1 = "/axi/can@ff070000";
+                cci = "/axi/cci@fd000000";
+                cci_pmu = "/axi/cci@fd000000/pmu@10000";
+                lpd_dma_chan0 = "/axi/dma-controller@ffa80000";
+                lpd_dma_chan1 = "/axi/dma-controller@ffa90000";
+                lpd_dma_chan2 = "/axi/dma-controller@ffaa0000";
+                lpd_dma_chan3 = "/axi/dma-controller@ffab0000";
+                lpd_dma_chan4 = "/axi/dma-controller@ffac0000";
+                lpd_dma_chan5 = "/axi/dma-controller@ffad0000";
+                lpd_dma_chan6 = "/axi/dma-controller@ffae0000";
+                lpd_dma_chan7 = "/axi/dma-controller@ffaf0000";
+                gem0 = "/axi/ethernet@ff0c0000";
+                mdio = "/axi/ethernet@ff0c0000/mdio";
+                phy1 = "/axi/ethernet@ff0c0000/mdio/ethernet-phy@1";
+                phy2 = "/axi/ethernet@ff0c0000/mdio/ethernet-phy@2";
+                gem1 = "/axi/ethernet@ff0d0000";
+                gpio0 = "/axi/gpio@ff0b0000";
+                gpio1 = "/axi/gpio@f1020000";
+                i2c0 = "/axi/i2c@ff020000";
+                i2c1 = "/axi/i2c@ff030000";
+                i2c2 = "/axi/i2c@f1000000";
+                mc0 = "/axi/memory-controller@f6150000";
+                mc1 = "/axi/memory-controller@f62c0000";
+                mc2 = "/axi/memory-controller@f6430000";
+                mc3 = "/axi/memory-controller@f65a0000";
+                ocm = "/axi/memory-controller@ff960000";
+                rtc = "/axi/rtc@f12a0000";
+                sdhci0 = "/axi/mmc@f1040000";
+                sdhci1 = "/axi/mmc@f1050000";
+                serial0 = "/axi/serial@ff000000";
+                serial1 = "/axi/serial@ff010000";
+                smmu = "/axi/iommu@fd800000";
+                ospi = "/axi/spi@f1010000";
+                qspi = "/axi/spi@f1030000";
+                spi0 = "/axi/spi@ff040000";
+                spi1 = "/axi/spi@ff050000";
+                sysmon0 = "/axi/sysmon@f1270000";
+                sysmon1 = "/axi/sysmon@109270000";
+                sysmon2 = "/axi/sysmon@111270000";
+                sysmon3 = "/axi/sysmon@119270000";
+                ttc0 = "/axi/timer@ff0e0000";
+                ttc1 = "/axi/timer@ff0f0000";
+                ttc2 = "/axi/timer@ff100000";
+                ttc3 = "/axi/timer@ff110000";
+                usb0 = "/axi/usb@ff9d0000";
+                dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
+                cpm_pciea = "/axi/pci@fca10000";
+                pcie_intc_0 = "/axi/pci@fca10000/interrupt-controller";
+                cpm5_pcie = "/axi/pcie@fcdd0000";
+                pcie_intc_2 = "/axi/pcie@fcdd0000/interrupt-controller";
+                watchdog = "/axi/watchdog@fd4d0000";
+                watchdog1 = "/axi/watchdog@ff120000";
+                xilsem_edac = "/axi/edac@f2014050";
+                dma0 = "/axi/pmcdma@f11c0000";
+                dma1 = "/axi/pmcdma@f11d0000";
+                iomodule0 = "/axi/iomodule@f0280000";
+                ipi_pmc = "/axi/mailbox@ff320000";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_0 = "/axi/mailbox@ff320000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_1 = "/axi/mailbox@ff320000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_2 = "/axi/mailbox@ff320000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_3 = "/axi/mailbox@ff320000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_4 = "/axi/mailbox@ff320000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_5 = "/axi/mailbox@ff320000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_6 = "/axi/mailbox@ff320000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_7 = "/axi/mailbox@ff320000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_8 = "/axi/mailbox@ff320000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_9 = "/axi/mailbox@ff320000/child@9";
+                ipi_pmc_nobuf = "/axi/mailbox@ff390000";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_0 = "/axi/mailbox@ff390000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_1 = "/axi/mailbox@ff390000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_2 = "/axi/mailbox@ff390000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_3 = "/axi/mailbox@ff390000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_4 = "/axi/mailbox@ff390000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_5 = "/axi/mailbox@ff390000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_6 = "/axi/mailbox@ff390000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_7 = "/axi/mailbox@ff390000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_8 = "/axi/mailbox@ff390000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_9 = "/axi/mailbox@ff390000/child@9";
+                ipi_psm = "/axi/mailbox@ff310000";
+                versal_cips_0_pspmc_0_psv_ipi_psm_0 = "/axi/mailbox@ff310000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_psm_1 = "/axi/mailbox@ff310000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_psm_2 = "/axi/mailbox@ff310000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_psm_3 = "/axi/mailbox@ff310000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_psm_4 = "/axi/mailbox@ff310000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_psm_5 = "/axi/mailbox@ff310000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_psm_6 = "/axi/mailbox@ff310000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_psm_7 = "/axi/mailbox@ff310000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_psm_8 = "/axi/mailbox@ff310000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_psm_9 = "/axi/mailbox@ff310000/child@9";
+                ipi0 = "/axi/mailbox@ff330000";
+                versal_cips_0_pspmc_0_psv_ipi_0_0 = "/axi/mailbox@ff330000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_0_1 = "/axi/mailbox@ff330000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_0_2 = "/axi/mailbox@ff330000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_0_3 = "/axi/mailbox@ff330000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_0_4 = "/axi/mailbox@ff330000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_0_5 = "/axi/mailbox@ff330000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_0_6 = "/axi/mailbox@ff330000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_0_7 = "/axi/mailbox@ff330000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_0_8 = "/axi/mailbox@ff330000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_0_9 = "/axi/mailbox@ff330000/child@9";
+                ipi1 = "/axi/mailbox@ff340000";
+                versal_cips_0_pspmc_0_psv_ipi_1_0 = "/axi/mailbox@ff340000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_1_1 = "/axi/mailbox@ff340000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_1_2 = "/axi/mailbox@ff340000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_1_3 = "/axi/mailbox@ff340000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_1_4 = "/axi/mailbox@ff340000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_1_5 = "/axi/mailbox@ff340000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_1_6 = "/axi/mailbox@ff340000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_1_7 = "/axi/mailbox@ff340000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_1_8 = "/axi/mailbox@ff340000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_1_9 = "/axi/mailbox@ff340000/child@9";
+                ipi2 = "/axi/mailbox@ff350000";
+                versal_cips_0_pspmc_0_psv_ipi_2_0 = "/axi/mailbox@ff350000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_2_1 = "/axi/mailbox@ff350000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_2_2 = "/axi/mailbox@ff350000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_2_3 = "/axi/mailbox@ff350000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_2_4 = "/axi/mailbox@ff350000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_2_5 = "/axi/mailbox@ff350000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_2_6 = "/axi/mailbox@ff350000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_2_7 = "/axi/mailbox@ff350000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_2_8 = "/axi/mailbox@ff350000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_2_9 = "/axi/mailbox@ff350000/child@9";
+                ipi3 = "/axi/mailbox@ff360000";
+                versal_cips_0_pspmc_0_psv_ipi_3_0 = "/axi/mailbox@ff360000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_3_1 = "/axi/mailbox@ff360000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_3_2 = "/axi/mailbox@ff360000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_3_3 = "/axi/mailbox@ff360000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_3_4 = "/axi/mailbox@ff360000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_3_5 = "/axi/mailbox@ff360000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_3_6 = "/axi/mailbox@ff360000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_3_7 = "/axi/mailbox@ff360000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_3_8 = "/axi/mailbox@ff360000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_3_9 = "/axi/mailbox@ff360000/child@9";
+                ipi4 = "/axi/mailbox@ff370000";
+                versal_cips_0_pspmc_0_psv_ipi_4_0 = "/axi/mailbox@ff370000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_4_1 = "/axi/mailbox@ff370000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_4_2 = "/axi/mailbox@ff370000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_4_3 = "/axi/mailbox@ff370000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_4_4 = "/axi/mailbox@ff370000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_4_5 = "/axi/mailbox@ff370000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_4_6 = "/axi/mailbox@ff370000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_4_7 = "/axi/mailbox@ff370000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_4_8 = "/axi/mailbox@ff370000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_4_9 = "/axi/mailbox@ff370000/child@9";
+                ipi5 = "/axi/mailbox@ff380000";
+                versal_cips_0_pspmc_0_psv_ipi_5_0 = "/axi/mailbox@ff380000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_5_1 = "/axi/mailbox@ff380000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_5_2 = "/axi/mailbox@ff380000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_5_3 = "/axi/mailbox@ff380000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_5_4 = "/axi/mailbox@ff380000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_5_5 = "/axi/mailbox@ff380000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_5_6 = "/axi/mailbox@ff380000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_5_7 = "/axi/mailbox@ff380000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_5_8 = "/axi/mailbox@ff380000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_5_9 = "/axi/mailbox@ff380000/child@9";
+                ipi6 = "/axi/mailbox@ff3a0000";
+                versal_cips_0_pspmc_0_psv_ipi_6_0 = "/axi/mailbox@ff3a0000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_6_1 = "/axi/mailbox@ff3a0000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_6_2 = "/axi/mailbox@ff3a0000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_6_3 = "/axi/mailbox@ff3a0000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_6_4 = "/axi/mailbox@ff3a0000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_6_5 = "/axi/mailbox@ff3a0000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_6_6 = "/axi/mailbox@ff3a0000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_6_7 = "/axi/mailbox@ff3a0000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_6_8 = "/axi/mailbox@ff3a0000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_6_9 = "/axi/mailbox@ff3a0000/child@9";
+                coresight = "/axi/coresight@f0800000";
+                versal_cips_0_cpm_0_psv_cpm = "/axi/versal_cips_0_cpm_0_psv_cpm@0";
+                versal_cips_0_pspmc_0_psv_apu_0 = "/axi/versal_cips_0_pspmc_0_psv_apu_0@fd5c0000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_cti = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_cti@f0d10000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_dbg = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_dbg@f0d00000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_etm = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_etm@f0d30000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_pmu = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_pmu@f0d20000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_cti = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_cti@f0d50000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_dbg = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_dbg@f0d40000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_etm = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_etm@f0d70000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_pmu = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_pmu@f0d60000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_cti = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_cti@f0ca0000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_ela = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_ela@f0c60000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_etf = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_etf@f0c30000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_fun = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_fun@f0c20000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_atm = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_atm@f0f80000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a@f0fa0000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d@f0fd0000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a@f0f40000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b@f0f50000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c@f0f60000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d@f0f70000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_fun = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_fun@f0f20000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_rom = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_rom@f0f00000";
+                versal_cips_0_pspmc_0_psv_coresight_fpd_atm = "/axi/versal_cips_0_pspmc_0_psv_coresight_fpd_atm@f0b80000";
+                versal_cips_0_pspmc_0_psv_coresight_fpd_stm = "/axi/versal_cips_0_pspmc_0_psv_coresight_fpd_stm@f0b70000";
+                versal_cips_0_pspmc_0_psv_coresight_lpd_atm = "/axi/versal_cips_0_pspmc_0_psv_coresight_lpd_atm@f0980000";
+                versal_cips_0_pspmc_0_psv_crf_0 = "/axi/versal_cips_0_pspmc_0_psv_crf_0@fd1a0000";
+                versal_cips_0_pspmc_0_psv_crl_0 = "/axi/versal_cips_0_pspmc_0_psv_crl_0@ff5e0000";
+                versal_cips_0_pspmc_0_psv_crp_0 = "/axi/versal_cips_0_pspmc_0_psv_crp_0@f1260000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_0@fd360000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_2 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_2@fd380000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_mem_0@a4000000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_2 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_mem_2@b0000000";
+                versal_cips_0_pspmc_0_psv_fpd_cci_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_cci_0@fd5e0000";
+                versal_cips_0_pspmc_0_psv_fpd_gpv_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_gpv_0@fd700000";
+                versal_cips_0_pspmc_0_psv_fpd_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_slcr_0@fd610000";
+                versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0@fd690000";
+                versal_cips_0_pspmc_0_psv_fpd_smmu_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_smmu_0@fd5f0000";
+                versal_cips_0_pspmc_0_psv_ipi_buffer = "/axi/versal_cips_0_pspmc_0_psv_ipi_buffer@ff3f0000";
+                versal_cips_0_pspmc_0_psv_lpd_afi_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_afi_0@ff9b0000";
+                versal_cips_0_pspmc_0_psv_lpd_afi_mem_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_afi_mem_0@80000000";
+                versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0@ff0a0000";
+                versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0@ff080000";
+                versal_cips_0_pspmc_0_psv_lpd_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_slcr_0@ff410000";
+                versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0@ff510000";
+                versal_cips_0_pspmc_0_psv_noc_pcie_0 = "/axi/versal_cips_0_pspmc_0_psv_noc_pcie_0@e0000000";
+                versal_cips_0_pspmc_0_psv_noc_pcie_1 = "/axi/versal_cips_0_pspmc_0_psv_noc_pcie_1@600000000";
+                versal_cips_0_pspmc_0_psv_noc_pcie_2 = "/axi/versal_cips_0_pspmc_0_psv_noc_pcie_2@8000000000";
+                versal_cips_0_pspmc_0_psv_ocm_ctrl = "/axi/versal_cips_0_pspmc_0_psv_ocm_ctrl@ff960000";
+                versal_cips_0_pspmc_0_psv_pmc_aes = "/axi/versal_cips_0_pspmc_0_psv_pmc_aes@f11e0000";
+                versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl = "/axi/versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl@f11f0000";
+                versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0@f12d0000";
+                versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0@f12b0000";
+                versal_cips_0_pspmc_0_psv_pmc_efuse_cache = "/axi/versal_cips_0_pspmc_0_psv_pmc_efuse_cache@f1250000";
+                versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl = "/axi/versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl@f1240000";
+                versal_cips_0_pspmc_0_psv_pmc_global_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_global_0@f1110000";
+                versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0@f0310000";
+                versal_cips_0_pspmc_0_psv_pmc_ram = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram@f2000000";
+                versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr@f0240000";
+                versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr@f0200000";
+                versal_cips_0_pspmc_0_psv_pmc_ram_npi = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram_npi@f6000000";
+                versal_cips_0_pspmc_0_psv_pmc_rsa = "/axi/versal_cips_0_pspmc_0_psv_pmc_rsa@f1200000";
+                versal_cips_0_pspmc_0_psv_pmc_sha = "/axi/versal_cips_0_pspmc_0_psv_pmc_sha@f1210000";
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot = "/axi/versal_cips_0_pspmc_0_psv_pmc_slave_boot@f1220000";
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream = "/axi/versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream@f2100000";
+                versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0@f0083000";
+                versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0@f0283000";
+                versal_cips_0_pspmc_0_psv_pmc_trng = "/axi/versal_cips_0_pspmc_0_psv_pmc_trng@f1230000";
+                versal_cips_0_pspmc_0_psv_psm_global_reg = "/axi/versal_cips_0_pspmc_0_psv_psm_global_reg@ffc90000";
+                versal_cips_0_pspmc_0_psv_psm_iomodule_0 = "/axi/versal_cips_0_pspmc_0_psv_psm_iomodule_0@ffc80000";
+                versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr = "/axi/versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr@ffc20000";
+                versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr = "/axi/versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr@ffc00000";
+                versal_cips_0_pspmc_0_psv_psm_tmr_inject_0 = "/axi/versal_cips_0_pspmc_0_psv_psm_tmr_inject_0@ffcd0000";
+                versal_cips_0_pspmc_0_psv_psm_tmr_manager_0 = "/axi/versal_cips_0_pspmc_0_psv_psm_tmr_manager_0@ffcc0000";
+                versal_cips_0_pspmc_0_psv_r5_0_atcm = "/axi/versal_cips_0_pspmc_0_psv_r5_0_atcm@0";
+                versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep = "/axi/versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep@ffe10000";
+                versal_cips_0_pspmc_0_psv_r5_0_btcm = "/axi/versal_cips_0_pspmc_0_psv_r5_0_btcm@20000";
+                versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep = "/axi/versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep@ffe30000";
+                versal_cips_0_pspmc_0_psv_r5_0_data_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_0_data_cache@ffe50000";
+                versal_cips_0_pspmc_0_psv_r5_0_instruction_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_0_instruction_cache@ffe40000";
+                versal_cips_0_pspmc_0_psv_r5_1_atcm = "/axi/versal_cips_0_pspmc_0_psv_r5_1_atcm@0";
+                versal_cips_0_pspmc_0_psv_r5_1_btcm = "/axi/versal_cips_0_pspmc_0_psv_r5_1_btcm@20000";
+                versal_cips_0_pspmc_0_psv_r5_1_data_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_1_data_cache@ffed0000";
+                versal_cips_0_pspmc_0_psv_r5_1_instruction_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_1_instruction_cache@ffec0000";
+                versal_cips_0_pspmc_0_psv_r5_tcm_ram_0 = "/axi/versal_cips_0_pspmc_0_psv_r5_tcm_ram_0@0";
+                versal_cips_0_pspmc_0_psv_rpu_0 = "/axi/versal_cips_0_pspmc_0_psv_rpu_0@ff9a0000";
+                versal_cips_0_pspmc_0_psv_scntr_0 = "/axi/versal_cips_0_pspmc_0_psv_scntr_0@ff130000";
+                versal_cips_0_pspmc_0_psv_scntrs_0 = "/axi/versal_cips_0_pspmc_0_psv_scntrs_0@ff140000";
+                psv_r5_0_atcm_global = "/psv_r5_0_atcm_global@ffe00000";
+                psv_r5_0_btcm_global = "/psv_r5_0_btcm_global@ffe20000";
+                psv_r5_1_atcm_global = "/psv_r5_1_atcm_global@ffe90000";
+                psv_r5_1_btcm_global = "/psv_r5_1_btcm_global@ffeb0000";
+                amba_xppu = "/indirect-bus@1";
+                lpd_xppu = "/indirect-bus@1/xppu@ff990000";
+                pmc_xppu = "/indirect-bus@1/xppu@f1310000";
+                pmc_xppu_npi = "/indirect-bus@1/xppu@f1300000";
+                amba_xmpu = "/indirect-bus@2";
+                fpd_xmpu = "/indirect-bus@2/xmpu@fd390000";
+                pmc_xmpu = "/indirect-bus@2/xmpu@f12f0000";
+                ocm_xmpu = "/indirect-bus@2/xmpu@ff980000";
+                ddrmc_xmpu_0 = "/indirect-bus@2/xmpu@f6080000";
+                ddrmc_xmpu_1 = "/indirect-bus@2/xmpu@f6220000";
+                ddrmc_xmpu_2 = "/indirect-bus@2/xmpu@f6390000";
+                ddrmc_xmpu_3 = "/indirect-bus@2/xmpu@f6500000";
+                pl_alt_ref_clk = "/pl_alt_ref_clk";
+                ref_clk = "/ref_clk";
+                can0_clk = "/can0_clk";
+                can1_clk = "/can1_clk";
+                versal_firmware = "/firmware/versal-firmware";
+                versal_clk = "/firmware/versal-firmware/clock-controller";
+                zynqmp_power = "/firmware/versal-firmware/zynqmp-power";
+                versal_reset = "/firmware/versal-firmware/reset-controller";
+                pinctrl0 = "/firmware/versal-firmware/pinctrl";
+                versal_sec_cfg = "/firmware/versal-firmware/versal-sec-cfg";
+                bbram_zeroize = "/firmware/versal-firmware/versal-sec-cfg/bbram-zeroize@4";
+                bbram_key = "/firmware/versal-firmware/versal-sec-cfg/bbram-key@10";
+                bbram_usr = "/firmware/versal-firmware/versal-sec-cfg/bbram-usr@30";
+                bbram_lock = "/firmware/versal-firmware/versal-sec-cfg/bbram-lock@48";
+                user_key0 = "/firmware/versal-firmware/versal-sec-cfg/user-key@110";
+                user_key1 = "/firmware/versal-firmware/versal-sec-cfg/user-key@130";
+                user_key2 = "/firmware/versal-firmware/versal-sec-cfg/user-key@150";
+                user_key3 = "/firmware/versal-firmware/versal-sec-cfg/user-key@170";
+                user_key4 = "/firmware/versal-firmware/versal-sec-cfg/user-key@190";
+                user_key5 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1b0";
+                user_key6 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1d0";
+                user_key7 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1f0";
+                amba_pl = "/amba_pl";
+                misc_clk_0 = "/amba_pl/misc_clk_0";
+                axi_bram_ctrl_0 = "/amba_pl/axi_bram_ctrl@0";
+                axi_gpio_0 = "/amba_pl/gpio@20200000000";
+                axi_gpio_1 = "/amba_pl/gpio@20200010000";
+                mailbox_0 = "/amba_pl/mailbox@20180000000";
+                pcie_qdma_mailbox_0 = "/amba_pl/pcie_qdma_mailbox@20800000000";
+                axi_noc_0_ddr_memory = "/memory@00000000";
+                versal_cips_0_pspmc_0_psv_ocm_ram_0_memory = "/memory@FFFC0000";
+        };
+};

--- a/meta-nile/conf/dts/kula-vmk180/kula-microblaze-psm.dts
+++ b/meta-nile/conf/dts/kula-vmk180/kula-microblaze-psm.dts
@@ -1,0 +1,5731 @@
+/dts-v1/;
+
+/ {
+        compatible = "xlnx,versal-vmk180-revA", "xlnx,versal";
+        #address-cells = <0x2>;
+        #size-cells = <0x2>;
+        model = "Xilinx Versal vmk180 Eval board revA";
+        board = "vmk180";
+        device_id = "xcvm1802";
+        slrcount = <0x1>;
+        family = "Versal";
+
+        options {
+
+                u-boot {
+                        compatible = "u-boot,config";
+                        bootscr-address = <0x0 0x20000000>;
+                };
+        };
+
+        cpus_a72: cpus-a72@0 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0x0 0xf0000000 &amba 0x0 0xf0000000 0x0 0x10000000>,
+                 <0x0 0xf9000000 &amba_apu 0x0 0xf9000000 0x0 0x80000>,
+                 <0x0 0x0 &axi_noc_0_ddr_memory 0x0 0x0 0x0 0x80000000>,
+                 <0x0 0xf9020000 &gic_its 0x0 0xf9020000 0x0 0x20000>,
+                 <0x0 0xff330000 &ipi0 0x0 0xff330000 0x0 0x10000>,
+                 <0x0 0xff340000 &ipi1 0x0 0xff340000 0x0 0x10000>,
+                 <0x0 0xff350000 &ipi2 0x0 0xff350000 0x0 0x10000>,
+                 <0x0 0xff360000 &ipi3 0x0 0xff360000 0x0 0x10000>,
+                 <0x0 0xff370000 &ipi4 0x0 0xff370000 0x0 0x10000>,
+                 <0x0 0xff380000 &ipi5 0x0 0xff380000 0x0 0x10000>,
+                 <0x0 0xff3a0000 &ipi6 0x0 0xff3a0000 0x0 0x10000>,
+                 <0x0 0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0x0 0xfffc0000 0x0 0x40000>,
+                 <0x0 0xe0000000 &versal_cips_0_pspmc_0_psv_noc_pcie_0 0x0 0xe0000000 0x0 0x10000000>,
+                 <0x0 0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0x0 0xf0310000 0x0 0x8000>,
+                 <0x0 0xf0800000 &coresight 0x0 0xf0800000 0x0 0x10000>,
+                 <0x0 0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0x0 0xf0980000 0x0 0x10000>,
+                 <0x0 0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0x0 0xf0b70000 0x0 0x10000>,
+                 <0x0 0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0x0 0xf0b80000 0x0 0x10000>,
+                 <0x0 0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0x0 0xf0c20000 0x0 0x10000>,
+                 <0x0 0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0x0 0xf0c30000 0x0 0x10000>,
+                 <0x0 0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0x0 0xf0c60000 0x0 0x10000>,
+                 <0x0 0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0x0 0xf0ca0000 0x0 0x10000>,
+                 <0x0 0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0x0 0xf0d00000 0x0 0x10000>,
+                 <0x0 0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0x0 0xf0d10000 0x0 0x10000>,
+                 <0x0 0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0x0 0xf0d20000 0x0 0x10000>,
+                 <0x0 0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0x0 0xf0d30000 0x0 0x10000>,
+                 <0x0 0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0x0 0xf0d40000 0x0 0x10000>,
+                 <0x0 0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0x0 0xf0d50000 0x0 0x10000>,
+                 <0x0 0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0x0 0xf0d60000 0x0 0x10000>,
+                 <0x0 0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0x0 0xf0d70000 0x0 0x10000>,
+                 <0x0 0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0x0 0xf0f00000 0x0 0x10000>,
+                 <0x0 0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0x0 0xf0f20000 0x0 0x10000>,
+                 <0x0 0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0x0 0xf0f40000 0x0 0x10000>,
+                 <0x0 0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0x0 0xf0f50000 0x0 0x10000>,
+                 <0x0 0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0x0 0xf0f60000 0x0 0x10000>,
+                 <0x0 0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0x0 0xf0f70000 0x0 0x10000>,
+                 <0x0 0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0x0 0xf0f80000 0x0 0x10000>,
+                 <0x0 0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0x0 0xf0fa0000 0x0 0x10000>,
+                 <0x0 0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0x0 0xf0fd0000 0x0 0x10000>,
+                 <0x0 0xf1000000 &i2c2 0x0 0xf1000000 0x0 0x10000>,
+                 <0x0 0xf1030000 &qspi 0x0 0xf1030000 0x0 0x10000>,
+                 <0x0 0xf1050000 &sdhci1 0x0 0xf1050000 0x0 0x10000>,
+                 <0x0 0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0x0 0xf1110000 0x0 0x50000>,
+                 <0x0 0xf11c0000 &dma0 0x0 0xf11c0000 0x0 0x10000>,
+                 <0x0 0xf11d0000 &dma1 0x0 0xf11d0000 0x0 0x10000>,
+                 <0x0 0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0x0 0xf11e0000 0x0 0x10000>,
+                 <0x0 0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0x0 0xf11f0000 0x0 0x10000>,
+                 <0x0 0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0x0 0xf1200000 0x0 0x10000>,
+                 <0x0 0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0x0 0xf1210000 0x0 0x10000>,
+                 <0x0 0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0x0 0xf1220000 0x0 0x10000>,
+                 <0x0 0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0x0 0xf1230000 0x0 0x10000>,
+                 <0x0 0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0x0 0xf1240000 0x0 0x10000>,
+                 <0x0 0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0x0 0xf1250000 0x0 0x10000>,
+                 <0x0 0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0x0 0xf1260000 0x0 0x10000>,
+                 <0x0 0xf1270000 &sysmon0 0x0 0xf1270000 0x0 0x30000>,
+                 <0x0 0xf12a0000 &rtc 0x0 0xf12a0000 0x0 0x10000>,
+                 <0x0 0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0x0 0xf12b0000 0x0 0x10000>,
+                 <0x0 0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0x0 0xf12d0000 0x0 0x1000>,
+                 <0x0 0xf12f0000 &pmc_xmpu 0x0 0xf12f0000 0x0 0x10000>,
+                 <0x0 0xf1300000 &pmc_xppu_npi 0x0 0xf1300000 0x0 0x10000>,
+                 <0x0 0xf1310000 &pmc_xppu 0x0 0xf1310000 0x0 0x10000>,
+                 <0x0 0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0x0 0xf2100000 0x0 0x10000>,
+                 <0x0 0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0x0 0xf6000000 0x0 0x2000000>,
+                 <0x0 0xf9000000 &gic_a72 0x0 0xf9000000 0x0 0x70000>,
+                 <0x0 0xfca10000 &cpm_pciea 0x0 0xfca10000 0x0 0x5f0000>,
+                 <0x0 0xfd000000 &cci 0x0 0xfd000000 0x0 0x100000>,
+                 <0x0 0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0x0 0xfd1a0000 0x0 0x140000>,
+                 <0x0 0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0x0 0xfd360000 0x0 0x10000>,
+                 <0x0 0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0x0 0xfd380000 0x0 0x10000>,
+                 <0x0 0xfd390000 &fpd_xmpu 0x0 0xfd390000 0x0 0x10000>,
+                 <0x0 0xfd5c0000 &versal_cips_0_pspmc_0_psv_apu_0 0x0 0xfd5c0000 0x0 0x10000>,
+                 <0x0 0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0x0 0xfd5e0000 0x0 0x10000>,
+                 <0x0 0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0x0 0xfd5f0000 0x0 0x10000>,
+                 <0x0 0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0x0 0xfd610000 0x0 0x10000>,
+                 <0x0 0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0x0 0xfd690000 0x0 0x10000>,
+                 <0x0 0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0x0 0xfd700000 0x0 0x100000>,
+                 <0x0 0xfd800000 &smmu 0x0 0xfd800000 0x0 0x800000>,
+                 <0x0 0xfe200000 &dwc3_0 0x0 0xfe200000 0x0 0x100000>,
+                 <0x0 0xff000000 &serial0 0x0 0xff000000 0x0 0x10000>,
+                 <0x0 0xff030000 &i2c1 0x0 0xff030000 0x0 0x10000>,
+                 <0x0 0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0x0 0xff080000 0x0 0x20000>,
+                 <0x0 0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0x0 0xff0a0000 0x0 0x10000>,
+                 <0x0 0xff0b0000 &gpio0 0x0 0xff0b0000 0x0 0x10000>,
+                 <0x0 0xff0c0000 &gem0 0x0 0xff0c0000 0x0 0x10000>,
+                 <0x0 0xff0e0000 &ttc0 0x0 0xff0e0000 0x0 0x10000>,
+                 <0x0 0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0x0 0xff130000 0x0 0x10000>,
+                 <0x0 0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0x0 0xff140000 0x0 0x10000>,
+                 <0x0 0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0x0 0xff410000 0x0 0x100000>,
+                 <0x0 0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0x0 0xff510000 0x0 0x40000>,
+                 <0x0 0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0x0 0xff5e0000 0x0 0x300000>,
+                 <0x0 0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0x0 0xff960000 0x0 0x10000>,
+                 <0x0 0xff980000 &ocm_xmpu 0x0 0xff980000 0x0 0x10000>,
+                 <0x0 0xff990000 &lpd_xppu 0x0 0xff990000 0x0 0x10000>,
+                 <0x0 0xff9a0000 &versal_cips_0_pspmc_0_psv_rpu_0 0x0 0xff9a0000 0x0 0x10000>,
+                 <0x0 0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0x0 0xff9b0000 0x0 0x10000>,
+                 <0x0 0xff9d0000 &usb0 0x0 0xff9d0000 0x0 0x10000>,
+                 <0x0 0xffa80000 &lpd_dma_chan0 0x0 0xffa80000 0x0 0x10000>,
+                 <0x0 0xffa90000 &lpd_dma_chan1 0x0 0xffa90000 0x0 0x10000>,
+                 <0x0 0xffaa0000 &lpd_dma_chan2 0x0 0xffaa0000 0x0 0x10000>,
+                 <0x0 0xffab0000 &lpd_dma_chan3 0x0 0xffab0000 0x0 0x10000>,
+                 <0x0 0xffac0000 &lpd_dma_chan4 0x0 0xffac0000 0x0 0x10000>,
+                 <0x0 0xffad0000 &lpd_dma_chan5 0x0 0xffad0000 0x0 0x10000>,
+                 <0x0 0xffae0000 &lpd_dma_chan6 0x0 0xffae0000 0x0 0x10000>,
+                 <0x0 0xffaf0000 &lpd_dma_chan7 0x0 0xffaf0000 0x0 0x10000>,
+                 <0x0 0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0x0 0xffc90000 0x0 0xf000>,
+                 <0x0 0xffe00000 &psv_r5_0_atcm_global 0x0 0xffe00000 0x0 0x40000>,
+                 <0x0 0xffe90000 &psv_r5_1_atcm_global 0x0 0xffe90000 0x0 0x10000>,
+                 <0x0 0xffeb0000 &psv_r5_1_btcm_global 0x0 0xffeb0000 0x0 0x10000>,
+                 <0x6 0x0 &versal_cips_0_pspmc_0_psv_noc_pcie_1 0x6 0x0 0x2 0x0>,
+                 <0x80 0x0 &versal_cips_0_pspmc_0_psv_noc_pcie_2 0x80 0x0 0x40 0x0>,
+                 <0x201 0x80000000 &mailbox_0 0x201 0x80000000 0x0 0x10000>,
+                 <0x202 0x0 &axi_gpio_0 0x202 0x0 0x0 0x10000>,
+                 <0x202 0x10000 &axi_gpio_1 0x202 0x10000 0x0 0x10000>,
+                 <0x208 0x0 &pcie_qdma_mailbox_0 0x208 0x0 0x0 0x80000000>;
+                #ranges-address-cells = <0x2>;
+                #ranges-size-cells = <0x2>;
+                phandle = <0x9d>;
+
+                psv_cortexa72_0: cpu@0 {
+                        compatible = "arm,cortex-a72", "arm,armv8";
+                        device_type = "cpu";
+                        enable-method = "psci";
+                        operating-points-v2 = <&cpu_opp_table>;
+                        reg = <0x0>;
+                        cpu-idle-states = <&CPU_SLEEP_0>;
+                        power-domains = <&versal_firmware 0x18110003>;
+                        clocks = <&versal_clk 0x4d>;
+                        xlnx,rable = <0x0>;
+                        xlnx,timestamp-clk-freq = <0x5f5dd19>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        stamp-frequency = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_cortexa72";
+                        xlnx,cpu-clk-freq-hz = <0x5372172a>;
+                        cpu-frequency = <0x5372172a>;
+                        bus-handle = <0x1>;
+                        phandle = <0x9e>;
+                };
+
+                psv_cortexa72_1: cpu@1 {
+                        compatible = "arm,cortex-a72", "arm,armv8";
+                        device_type = "cpu";
+                        enable-method = "psci";
+                        operating-points-v2 = <&cpu_opp_table>;
+                        reg = <0x1>;
+                        cpu-idle-states = <&CPU_SLEEP_0>;
+                        power-domains = <&versal_firmware 0x18110004>;
+                        xlnx,rable = <0x0>;
+                        xlnx,timestamp-clk-freq = <0x5f5dd19>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        stamp-frequency = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_cortexa72";
+                        xlnx,cpu-clk-freq-hz = <0x5372172a>;
+                        cpu-frequency = <0x5372172a>;
+                        bus-handle = <0x1>;
+                        phandle = <0x9f>;
+                };
+
+                idle-states {
+                        entry-method = "psci";
+
+                        CPU_SLEEP_0: cpu-sleep-0 {
+                                compatible = "arm,idle-state";
+                                arm,psci-suspend-param = <0x40000000>;
+                                local-timer-stop;
+                                entry-latency-us = <0x12c>;
+                                exit-latency-us = <0x258>;
+                                min-residency-us = <0x2710>;
+                                phandle = <0x74>;
+                        };
+                };
+        };
+
+        cpus_microblaze_0: cpus_microblaze@0 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0x0 &axi_noc_0_ddr_memory 0x0 0x80000000>,
+                 <0xff320000 &ipi_pmc 0xff320000 0x10000>,
+                 <0xff390000 &ipi_pmc_nobuf 0xff390000 0x10000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfca10000 &cpm_pciea 0xfca10000 0x5f0000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0xffe00000 &psv_r5_0_atcm_global 0xffe00000 0x40000>,
+                 <0xffe90000 &psv_r5_1_atcm_global 0xffe90000 0x10000>,
+                 <0xffeb0000 &psv_r5_1_btcm_global 0xffeb0000 0x10000>,
+                 <0xf0083000 &versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0 0xf0083000 0x1000>,
+                 <0xf0200000 &versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr 0xf0200000 0x40000>,
+                 <0xf0240000 &versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr 0xf0240000 0x20000>,
+                 <0xf0280000 &iomodule0 0xf0280000 0x1000>,
+                 <0xf0283000 &versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0 0xf0283000 0x1000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa0>;
+
+                psv_pmc_0: cpu@0 {
+                        compatible = "pmc-microblaze";
+                        device_type = "cpu";
+                        reg = <0x0>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        xlnx,d-axi = <0x1>;
+                        xlnx,addr-tag-bits = <0x0>;
+                        xlnx,m-axi-dc-thread-id-width = <0x1>;
+                        xlnx,m0-axis-protocol = "GENERIC";
+                        xlnx,dcache-force-tag-lutram = <0x0>;
+                        xlnx,interrupt-is-edge = <0x0>;
+                        xlnx,use-mmu = <0x0>;
+                        xlnx,m-axi-dp-exclusive-access = <0x0>;
+                        xlnx,use-reorder-instr = <0x1>;
+                        xlnx,m14-axis-protocol = "GENERIC";
+                        xlnx,use-div = <0x1>;
+                        xlnx,dc-axi-mon = <0x0>;
+                        xlnx,m-axi-ic-user-signals = <0x0>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,s14-axis-protocol = "GENERIC";
+                        xlnx,mmu-zones = <0x10>;
+                        xlnx,enable-discrete-ports = <0x0>;
+                        xlnx,d-lmb = <0x1>;
+                        xlnx,m-axi-dc-exclusive-access = <0x0>;
+                        xlnx,debug-interface = <0x0>;
+                        xlnx,s9-axis-protocol = "GENERIC";
+                        xlnx,sco = <0x0>;
+                        xlnx,use-ext-brk = <0x0>;
+                        xlnx,debug-enabled = <0x1>;
+                        xlnx,daddr-size = <0x20>;
+                        xlnx,s0-axis-data-width = <0x20>;
+                        xlnx,use-extended-fsl-instr = <0x0>;
+                        xlnx,m-axi-dc-user-signals = <0x0>;
+                        xlnx,reset-msr = <0x0>;
+                        xlnx,branch-target-cache-size = <0x0>;
+                        xlnx,s2-axis-data-width = <0x20>;
+                        xlnx,cache-byte-size = <0x2000>;
+                        bus-handle = <0x1>;
+                        xlnx,mmu-tlb-access = <0x3>;
+                        xlnx,s4-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-awuser-width = <0x5>;
+                        xlnx,s6-axis-data-width = <0x20>;
+                        xlnx,s4-axis-protocol = "GENERIC";
+                        xlnx,s8-axis-data-width = <0x20>;
+                        xlnx,edk-special = "microblaze";
+                        xlnx,use-dcache = <0x0>;
+                        xlnx,m-axi-dp-addr-width = <0x20>;
+                        xlnx,m-axi-ic-wuser-width = <0x1>;
+                        xlnx,i-axi = <0x0>;
+                        xlnx,icache-streams = <0x0>;
+                        xlnx,m-axi-dc-awuser-width = <0x5>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,use-stack-protection = <0x1>;
+                        xlnx,m6-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-dbg-clk = <0x1>;
+                        xlnx,m-axi-ip-data-width = <0x20>;
+                        d-cache-size = <0x2000>;
+                        xlnx,use-pcmp-instr = <0x1>;
+                        xlnx,area-optimized = <0x0>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,m1-axis-protocol = "GENERIC";
+                        xlnx,i-lmb = <0x1>;
+                        xlnx,lockstep-select = <0x0>;
+                        xlnx,dcache-data-width = <0x0>;
+                        xlnx,icache-force-tag-lutram = <0x0>;
+                        xlnx,m15-axis-protocol = "GENERIC";
+                        xlnx,use-branch-target-cache = <0x0>;
+                        xlnx,m-axi-ip-thread-id-width = <0x1>;
+                        xlnx,mmu-itlb-size = <0x2>;
+                        xlnx,number-of-pc-brk = <0x2>;
+                        xlnx,imprecise-exceptions = <0x0>;
+                        xlnx,m-axi-ic-buser-width = <0x1>;
+                        xlnx,m-axi-ic-addr-width = <0x20>;
+                        xlnx,s15-axis-protocol = "GENERIC";
+                        d-cache-highaddr = <0x3fffffff>;
+                        xlnx,m10-axis-protocol = "GENERIC";
+                        xlnx,optimization = <0x0>;
+                        xlnx,m-axi-ic-aruser-width = <0x5>;
+                        xlnx,d-lmb-mon = <0x0>;
+                        xlnx,s10-axis-protocol = "GENERIC";
+                        xlnx,m-axi-ic-ruser-width = <0x1>;
+                        xlnx,s5-axis-protocol = "GENERIC";
+                        xlnx,fault-tolerant = <0x1>;
+                        d-cache-line-size = <0x10>;
+                        xlnx,m-axi-dc-aruser-width = <0x5>;
+                        xlnx,mmu-privileged-instr = <0x0>;
+                        xlnx,m-axi-i-bus-exception = <0x0>;
+                        xlnx,reset-msr-eip = <0x0>;
+                        xlnx,endianness = <0x1>;
+                        xlnx,reset-msr-ice = <0x0>;
+                        xlnx,dp-axi-mon = <0x0>;
+                        xlnx,s10-axis-data-width = <0x20>;
+                        xlnx,s0-axis-protocol = "GENERIC";
+                        xlnx,s12-axis-data-width = <0x20>;
+                        xlnx,m7-axis-protocol = "GENERIC";
+                        xlnx,s14-axis-data-width = <0x20>;
+                        xlnx,m-axi-d-bus-exception = <0x1>;
+                        xlnx,reset-msr-bip = <0x1>;
+                        xlnx,debug-external-trace = <0x0>;
+                        xlnx,addr-size = <0x20>;
+                        xlnx,m-axi-ic-user-value = <0x1f>;
+                        xlnx,m1-axis-data-width = <0x20>;
+                        xlnx,debug-event-counters = <0x5>;
+                        xlnx,m3-axis-data-width = <0x20>;
+                        xlnx,fpu-exception = <0x0>;
+                        xlnx,m2-axis-protocol = "GENERIC";
+                        xlnx,m5-axis-data-width = <0x20>;
+                        xlnx,m7-axis-data-width = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        xlnx,debug-latency-counters = <0x1>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,m9-axis-data-width = <0x20>;
+                        xlnx,edge-is-positive = <0x1>;
+                        xlnx,use-icache = <0x0>;
+                        xlnx,async-wakeup = <0x3>;
+                        xlnx,m10-axis-data-width = <0x20>;
+                        xlnx,m12-axis-data-width = <0x20>;
+                        xlnx,use-ext-nm-brk = <0x0>;
+                        xlnx,m11-axis-protocol = "GENERIC";
+                        xlnx,m14-axis-data-width = <0x20>;
+                        xlnx,icache-always-used = <0x0>;
+                        xlnx,ic-axi-mon = <0x0>;
+                        xlnx,num-sync-ff-clk-irq = <0x1>;
+                        xlnx,freq = <0x1312d000>;
+                        xlnx,lockstep-master = <0x0>;
+                        xlnx,s11-axis-protocol = "GENERIC";
+                        xlnx,use-msr-instr = <0x1>;
+                        xlnx,s6-axis-protocol = "GENERIC";
+                        xlnx,iaddr-size = <0x20>;
+                        xlnx,interrupt-mon = <0x0>;
+                        xlnx,m-axi-dc-data-width = <0x20>;
+                        xlnx,dynamic-bus-sizing = <0x0>;
+                        xlnx,number-of-wr-addr-brk = <0x1>;
+                        xlnx,use-interrupt = <0x1>;
+                        xlnx,m-axi-ip-addr-width = <0x20>;
+                        xlnx,async-interrupt = <0x1>;
+                        xlnx,pc-width = <0x20>;
+                        xlnx,icache-victims = <0x0>;
+                        xlnx,reset-msr-ee = <0x0>;
+                        xlnx,s1-axis-protocol = "GENERIC";
+                        xlnx,m8-axis-protocol = "GENERIC";
+                        i-cache-baseaddr = <0x0>;
+                        xlnx,i-lmb-mon = <0x0>;
+                        xlnx,dcache-byte-size = <0x2000>;
+                        xlnx,m-axi-dp-thread-id-width = <0x1>;
+                        xlnx,data-size = <0x20>;
+                        xlnx,m-axi-dc-wuser-width = <0x1>;
+                        xlnx,fsl-exception = <0x0>;
+                        xlnx,m3-axis-protocol = "GENERIC";
+                        xlnx,s1-axis-data-width = <0x20>;
+                        xlnx,dcache-use-writeback = <0x0>;
+                        xlnx,div-zero-exception = <0x1>;
+                        xlnx,s3-axis-data-width = <0x20>;
+                        xlnx,base-vectors = <0xf0240000>;
+                        xlnx,icache-line-len = <0x4>;
+                        xlnx,s5-axis-data-width = <0x20>;
+                        xlnx,s7-axis-data-width = <0x20>;
+                        xlnx,allow-dcache-wr = <0x1>;
+                        xlnx,s9-axis-data-width = <0x20>;
+                        xlnx,use-barrel = <0x1>;
+                        xlnx,g-use-exceptions = <0x1>;
+                        xlnx,dcache-line-len = <0x4>;
+                        xlnx,m12-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-clk = <0x2>;
+                        i-cache-size = <0x2000>;
+                        xlnx,instance = "design_1_microblaze_0_0";
+                        xlnx,reset-msr-ie = <0x0>;
+                        xlnx,s12-axis-protocol = "GENERIC";
+                        xlnx,dcache-addr-tag = <0x0>;
+                        xlnx,m-axi-ic-thread-id-width = <0x1>;
+                        xlnx,number-of-rd-addr-brk = <0x1>;
+                        xlnx,m-axi-dc-buser-width = <0x1>;
+                        xlnx,s7-axis-protocol = "GENERIC";
+                        xlnx,lockstep-slave = <0x0>;
+                        xlnx,debug-profile-size = <0x0>;
+                        xlnx,s2-axis-protocol = "GENERIC";
+                        xlnx,m9-axis-protocol = "GENERIC";
+                        xlnx,debug-counter-width = <0x20>;
+                        xlnx,icache-data-width = <0x0>;
+                        xlnx,m-axi-dc-ruser-width = <0x1>;
+                        xlnx,reset-msr-dce = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc";
+                        xlnx,ip-axi-mon = <0x0>;
+                        xlnx,m-axi-dp-data-width = <0x20>;
+                        xlnx,m4-axis-protocol = "GENERIC";
+                        xlnx,dcache-always-used = <0x0>;
+                        xlnx,ill-opcode-exception = <0x1>;
+                        xlnx,trace = <0x1>;
+                        xlnx,pvr = <0x2>;
+                        xlnx,debug-trace-size = <0x2000>;
+                        i-cache-line-size = <0x10>;
+                        xlnx,m13-axis-protocol = "GENERIC";
+                        xlnx,s11-axis-data-width = <0x20>;
+                        xlnx,m-axi-dc-addr-width = <0x20>;
+                        xlnx,s13-axis-data-width = <0x20>;
+                        xlnx,ecc-use-ce-exception = <0x0>;
+                        xlnx,opcode-0x0-illegal = <0x1>;
+                        xlnx,pvr-user2 = <0x0>;
+                        xlnx,s15-axis-data-width = <0x20>;
+                        xlnx,s13-axis-protocol = "GENERIC";
+                        xlnx,m0-axis-data-width = <0x20>;
+                        i-cache-highaddr = <0x3fffffff>;
+                        xlnx,s8-axis-protocol = "GENERIC";
+                        xlnx,m2-axis-data-width = <0x20>;
+                        xlnx,num-sync-ff-clk-debug = <0x2>;
+                        xlnx,allow-icache-wr = <0x1>;
+                        xlnx,m4-axis-data-width = <0x20>;
+                        xlnx,g-template-list = <0x0>;
+                        xlnx,m6-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-data-width = <0x20>;
+                        xlnx,m8-axis-data-width = <0x20>;
+                        xlnx,use-hw-mul = <0x2>;
+                        xlnx,use-fpu = <0x0>;
+                        xlnx,s3-axis-protocol = "GENERIC";
+                        xlnx,use-non-secure = <0x0>;
+                        d-cache-baseaddr = <0x0>;
+                        xlnx,m11-axis-data-width = <0x20>;
+                        xlnx,m13-axis-data-width = <0x20>;
+                        xlnx,instr-size = <0x20>;
+                        xlnx,m15-axis-data-width = <0x20>;
+                        xlnx,mmu-dtlb-size = <0x4>;
+                        xlnx,fsl-links = <0x0>;
+                        xlnx,m5-axis-protocol = "GENERIC";
+                        xlnx,dcache-victims = <0x0>;
+                        xlnx,m-axi-dc-user-value = <0x1f>;
+                        xlnx,unaligned-exceptions = <0x1>;
+                        phandle = <0xa1>;
+                };
+        };
+
+        cpus_microblaze_1: cpus_microblaze@1 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0x0 &axi_noc_0_ddr_memory 0x0 0x80000000>,
+                 <0xff310000 &ipi_psm 0xff310000 0x10000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0xffe00000 &psv_r5_0_atcm_global 0xffe00000 0x40000>,
+                 <0xffe90000 &psv_r5_1_atcm_global 0xffe90000 0x10000>,
+                 <0xffeb0000 &psv_r5_1_btcm_global 0xffeb0000 0x10000>,
+                 <0xffc00000 &versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr 0xffc00000 0x20000>,
+                 <0xffc20000 &versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr 0xffc20000 0x20000>,
+                 <0xffc80000 &versal_cips_0_pspmc_0_psv_psm_iomodule_0 0xffc80000 0x8000>,
+                 <0xffcc0000 &versal_cips_0_pspmc_0_psv_psm_tmr_manager_0 0xffcc0000 0x10000>,
+                 <0xffcd0000 &versal_cips_0_pspmc_0_psv_psm_tmr_inject_0 0xffcd0000 0x10000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa2>;
+
+                psv_psm_0: cpu@0 {
+                        compatible = "psm-microblaze";
+                        device_type = "cpu";
+                        reg = <0x1>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        xlnx,d-axi = <0x1>;
+                        xlnx,addr-tag-bits = <0x0>;
+                        xlnx,m-axi-dc-thread-id-width = <0x1>;
+                        xlnx,m0-axis-protocol = "GENERIC";
+                        xlnx,dcache-force-tag-lutram = <0x0>;
+                        xlnx,interrupt-is-edge = <0x0>;
+                        xlnx,use-mmu = <0x0>;
+                        xlnx,m-axi-dp-exclusive-access = <0x0>;
+                        xlnx,use-reorder-instr = <0x1>;
+                        xlnx,m14-axis-protocol = "GENERIC";
+                        xlnx,use-div = <0x1>;
+                        xlnx,dc-axi-mon = <0x0>;
+                        xlnx,m-axi-ic-user-signals = <0x0>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,s14-axis-protocol = "GENERIC";
+                        xlnx,mmu-zones = <0x10>;
+                        xlnx,enable-discrete-ports = <0x0>;
+                        xlnx,d-lmb = <0x1>;
+                        xlnx,m-axi-dc-exclusive-access = <0x0>;
+                        xlnx,debug-interface = <0x0>;
+                        xlnx,s9-axis-protocol = "GENERIC";
+                        xlnx,sco = <0x0>;
+                        xlnx,use-ext-brk = <0x0>;
+                        xlnx,debug-enabled = <0x1>;
+                        xlnx,daddr-size = <0x20>;
+                        xlnx,s0-axis-data-width = <0x20>;
+                        xlnx,use-extended-fsl-instr = <0x0>;
+                        xlnx,m-axi-dc-user-signals = <0x0>;
+                        xlnx,reset-msr = <0x0>;
+                        xlnx,branch-target-cache-size = <0x0>;
+                        xlnx,s2-axis-data-width = <0x20>;
+                        bus-handle = <0x1>;
+                        xlnx,cache-byte-size = <0x2000>;
+                        xlnx,mmu-tlb-access = <0x3>;
+                        xlnx,s4-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-awuser-width = <0x5>;
+                        xlnx,s6-axis-data-width = <0x20>;
+                        xlnx,s4-axis-protocol = "GENERIC";
+                        xlnx,s8-axis-data-width = <0x20>;
+                        xlnx,edk-special = "microblaze";
+                        xlnx,use-dcache = <0x0>;
+                        xlnx,m-axi-dp-addr-width = <0x20>;
+                        xlnx,m-axi-ic-wuser-width = <0x1>;
+                        xlnx,i-axi = <0x0>;
+                        xlnx,icache-streams = <0x0>;
+                        xlnx,m-axi-dc-awuser-width = <0x5>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,use-stack-protection = <0x1>;
+                        xlnx,m6-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-dbg-clk = <0x1>;
+                        xlnx,m-axi-ip-data-width = <0x20>;
+                        d-cache-size = <0x2000>;
+                        xlnx,use-pcmp-instr = <0x1>;
+                        xlnx,area-optimized = <0x0>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,m1-axis-protocol = "GENERIC";
+                        xlnx,i-lmb = <0x1>;
+                        xlnx,lockstep-select = <0x0>;
+                        xlnx,dcache-data-width = <0x0>;
+                        xlnx,icache-force-tag-lutram = <0x0>;
+                        xlnx,m15-axis-protocol = "GENERIC";
+                        xlnx,use-branch-target-cache = <0x0>;
+                        xlnx,m-axi-ip-thread-id-width = <0x1>;
+                        xlnx,mmu-itlb-size = <0x2>;
+                        xlnx,number-of-pc-brk = <0x2>;
+                        xlnx,imprecise-exceptions = <0x0>;
+                        xlnx,m-axi-ic-buser-width = <0x1>;
+                        xlnx,m-axi-ic-addr-width = <0x20>;
+                        xlnx,s15-axis-protocol = "GENERIC";
+                        d-cache-highaddr = <0x3fffffff>;
+                        xlnx,m10-axis-protocol = "GENERIC";
+                        xlnx,optimization = <0x0>;
+                        xlnx,m-axi-ic-aruser-width = <0x5>;
+                        xlnx,d-lmb-mon = <0x0>;
+                        xlnx,s10-axis-protocol = "GENERIC";
+                        xlnx,m-axi-ic-ruser-width = <0x1>;
+                        xlnx,s5-axis-protocol = "GENERIC";
+                        xlnx,fault-tolerant = <0x1>;
+                        d-cache-line-size = <0x10>;
+                        xlnx,m-axi-dc-aruser-width = <0x5>;
+                        xlnx,mmu-privileged-instr = <0x0>;
+                        xlnx,m-axi-i-bus-exception = <0x0>;
+                        xlnx,reset-msr-eip = <0x0>;
+                        xlnx,endianness = <0x1>;
+                        xlnx,reset-msr-ice = <0x0>;
+                        xlnx,dp-axi-mon = <0x0>;
+                        xlnx,s10-axis-data-width = <0x20>;
+                        xlnx,s0-axis-protocol = "GENERIC";
+                        xlnx,s12-axis-data-width = <0x20>;
+                        xlnx,m7-axis-protocol = "GENERIC";
+                        xlnx,s14-axis-data-width = <0x20>;
+                        xlnx,m-axi-d-bus-exception = <0x1>;
+                        xlnx,reset-msr-bip = <0x1>;
+                        xlnx,debug-external-trace = <0x0>;
+                        xlnx,addr-size = <0x20>;
+                        xlnx,m-axi-ic-user-value = <0x1f>;
+                        xlnx,m1-axis-data-width = <0x20>;
+                        xlnx,debug-event-counters = <0x5>;
+                        xlnx,m3-axis-data-width = <0x20>;
+                        xlnx,fpu-exception = <0x0>;
+                        xlnx,m2-axis-protocol = "GENERIC";
+                        xlnx,m5-axis-data-width = <0x20>;
+                        xlnx,m7-axis-data-width = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        xlnx,debug-latency-counters = <0x1>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,m9-axis-data-width = <0x20>;
+                        xlnx,edge-is-positive = <0x1>;
+                        xlnx,use-icache = <0x0>;
+                        xlnx,async-wakeup = <0x3>;
+                        xlnx,m10-axis-data-width = <0x20>;
+                        xlnx,m12-axis-data-width = <0x20>;
+                        xlnx,use-ext-nm-brk = <0x0>;
+                        xlnx,m11-axis-protocol = "GENERIC";
+                        xlnx,m14-axis-data-width = <0x20>;
+                        xlnx,icache-always-used = <0x0>;
+                        xlnx,ic-axi-mon = <0x0>;
+                        xlnx,num-sync-ff-clk-irq = <0x1>;
+                        xlnx,freq = <0x5f5e100>;
+                        xlnx,lockstep-master = <0x0>;
+                        xlnx,s11-axis-protocol = "GENERIC";
+                        xlnx,use-msr-instr = <0x1>;
+                        xlnx,s6-axis-protocol = "GENERIC";
+                        xlnx,iaddr-size = <0x20>;
+                        xlnx,interrupt-mon = <0x0>;
+                        xlnx,m-axi-dc-data-width = <0x20>;
+                        xlnx,dynamic-bus-sizing = <0x0>;
+                        xlnx,number-of-wr-addr-brk = <0x1>;
+                        xlnx,use-interrupt = <0x1>;
+                        xlnx,m-axi-ip-addr-width = <0x20>;
+                        xlnx,async-interrupt = <0x1>;
+                        xlnx,pc-width = <0x20>;
+                        xlnx,icache-victims = <0x0>;
+                        xlnx,reset-msr-ee = <0x0>;
+                        xlnx,s1-axis-protocol = "GENERIC";
+                        xlnx,m8-axis-protocol = "GENERIC";
+                        i-cache-baseaddr = <0x0>;
+                        xlnx,i-lmb-mon = <0x0>;
+                        xlnx,dcache-byte-size = <0x2000>;
+                        xlnx,m-axi-dp-thread-id-width = <0x1>;
+                        xlnx,data-size = <0x20>;
+                        xlnx,m-axi-dc-wuser-width = <0x1>;
+                        xlnx,fsl-exception = <0x0>;
+                        xlnx,m3-axis-protocol = "GENERIC";
+                        xlnx,s1-axis-data-width = <0x20>;
+                        xlnx,dcache-use-writeback = <0x0>;
+                        xlnx,div-zero-exception = <0x1>;
+                        xlnx,s3-axis-data-width = <0x20>;
+                        xlnx,base-vectors = <0xffc00000>;
+                        xlnx,icache-line-len = <0x4>;
+                        xlnx,s5-axis-data-width = <0x20>;
+                        xlnx,s7-axis-data-width = <0x20>;
+                        xlnx,allow-dcache-wr = <0x1>;
+                        xlnx,s9-axis-data-width = <0x20>;
+                        xlnx,use-barrel = <0x1>;
+                        xlnx,g-use-exceptions = <0x1>;
+                        xlnx,dcache-line-len = <0x4>;
+                        xlnx,m12-axis-protocol = "GENERIC";
+                        xlnx,num-sync-ff-clk = <0x2>;
+                        i-cache-size = <0x2000>;
+                        xlnx,instance = "design_1_microblaze_0_0";
+                        xlnx,reset-msr-ie = <0x0>;
+                        xlnx,s12-axis-protocol = "GENERIC";
+                        xlnx,dcache-addr-tag = <0x0>;
+                        xlnx,m-axi-ic-thread-id-width = <0x1>;
+                        xlnx,number-of-rd-addr-brk = <0x1>;
+                        xlnx,m-axi-dc-buser-width = <0x1>;
+                        xlnx,s7-axis-protocol = "GENERIC";
+                        xlnx,lockstep-slave = <0x0>;
+                        xlnx,debug-profile-size = <0x0>;
+                        xlnx,s2-axis-protocol = "GENERIC";
+                        xlnx,m9-axis-protocol = "GENERIC";
+                        xlnx,debug-counter-width = <0x20>;
+                        xlnx,icache-data-width = <0x0>;
+                        xlnx,m-axi-dc-ruser-width = <0x1>;
+                        xlnx,reset-msr-dce = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_psm";
+                        xlnx,ip-axi-mon = <0x0>;
+                        xlnx,m-axi-dp-data-width = <0x20>;
+                        xlnx,m4-axis-protocol = "GENERIC";
+                        xlnx,dcache-always-used = <0x0>;
+                        xlnx,ill-opcode-exception = <0x1>;
+                        xlnx,trace = <0x1>;
+                        xlnx,pvr = <0x2>;
+                        xlnx,debug-trace-size = <0x2000>;
+                        i-cache-line-size = <0x10>;
+                        xlnx,m13-axis-protocol = "GENERIC";
+                        xlnx,s11-axis-data-width = <0x20>;
+                        xlnx,m-axi-dc-addr-width = <0x20>;
+                        xlnx,s13-axis-data-width = <0x20>;
+                        xlnx,ecc-use-ce-exception = <0x0>;
+                        xlnx,opcode-0x0-illegal = <0x1>;
+                        xlnx,pvr-user2 = <0x0>;
+                        xlnx,s15-axis-data-width = <0x20>;
+                        xlnx,s13-axis-protocol = "GENERIC";
+                        xlnx,m0-axis-data-width = <0x20>;
+                        i-cache-highaddr = <0x3fffffff>;
+                        xlnx,s8-axis-protocol = "GENERIC";
+                        xlnx,m2-axis-data-width = <0x20>;
+                        xlnx,num-sync-ff-clk-debug = <0x2>;
+                        xlnx,allow-icache-wr = <0x1>;
+                        xlnx,m4-axis-data-width = <0x20>;
+                        xlnx,g-template-list = <0x0>;
+                        xlnx,m6-axis-data-width = <0x20>;
+                        xlnx,m-axi-ic-data-width = <0x20>;
+                        xlnx,m8-axis-data-width = <0x20>;
+                        xlnx,use-hw-mul = <0x2>;
+                        xlnx,use-fpu = <0x0>;
+                        xlnx,s3-axis-protocol = "GENERIC";
+                        xlnx,use-non-secure = <0x0>;
+                        d-cache-baseaddr = <0x0>;
+                        xlnx,m11-axis-data-width = <0x20>;
+                        xlnx,m13-axis-data-width = <0x20>;
+                        xlnx,instr-size = <0x20>;
+                        xlnx,m15-axis-data-width = <0x20>;
+                        xlnx,mmu-dtlb-size = <0x4>;
+                        xlnx,fsl-links = <0x0>;
+                        xlnx,m5-axis-protocol = "GENERIC";
+                        xlnx,dcache-victims = <0x0>;
+                        xlnx,m-axi-dc-user-value = <0x1f>;
+                        xlnx,unaligned-exceptions = <0x1>;
+                        phandle = <0xa3>;
+                };
+        };
+
+        cpus_r5_0: cpus-r5@0 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0xf9000000 &amba_rpu 0xf9000000 0x3000>,
+                 <0x40000 &axi_noc_0_ddr_memory 0x40000 0x7ffc0000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0800000 &coresight 0xf0800000 0x10000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5c0000 &versal_cips_0_pspmc_0_psv_apu_0 0xfd5c0000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9a0000 &versal_cips_0_pspmc_0_psv_rpu_0 0xff9a0000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_0_atcm 0x0 0x10000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_tcm_ram_0 0x0 0x40000>,
+                 <0x20000 &versal_cips_0_pspmc_0_psv_r5_0_btcm 0x20000 0x10000>,
+                 <0xf9000000 &gic_r5 0xf9000000 0x3000>,
+                 <0xffe40000 &versal_cips_0_pspmc_0_psv_r5_0_instruction_cache 0xffe40000 0x10000>,
+                 <0xffe50000 &versal_cips_0_pspmc_0_psv_r5_0_data_cache 0xffe50000 0x10000>,
+                 <0xffec0000 &versal_cips_0_pspmc_0_psv_r5_1_instruction_cache 0xffec0000 0x10000>,
+                 <0xffed0000 &versal_cips_0_pspmc_0_psv_r5_1_data_cache 0xffed0000 0x10000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa4>;
+
+                psv_cortexr5_0: cpu@0 {
+                        compatible = "arm,cortex-r5";
+                        device_type = "cpu";
+                        reg = <0x0>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        power-domains = <&versal_firmware 0x18110005>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,ip-name = "psv_cortexr5";
+                        access-val = <0xff>;
+                        bus-handle = <0x1>;
+                        xlnx,cpu-clk-freq-hz = <0x23c32ea3>;
+                        cpu-frequency = <0x23c32ea3>;
+                        phandle = <0xa5>;
+                };
+        };
+
+        cpus_r5_1: cpus-r5@1 {
+                #address-cells = <0x1>;
+                #size-cells = <0x0>;
+                compatible = "cpus,cluster";
+                address-map = <0xf0000000 &amba 0xf0000000 0x10000000>,
+                 <0xf9000000 &amba_rpu 0xf9000000 0x3000>,
+                 <0x40000 &axi_noc_0_ddr_memory 0x40000 0x7ffc0000>,
+                 <0xfffc0000 &versal_cips_0_pspmc_0_psv_ocm_ram_0_memory 0xfffc0000 0x40000>,
+                 <0xf0310000 &versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 0xf0310000 0x8000>,
+                 <0xf0800000 &coresight 0xf0800000 0x10000>,
+                 <0xf0980000 &versal_cips_0_pspmc_0_psv_coresight_lpd_atm 0xf0980000 0x10000>,
+                 <0xf0b70000 &versal_cips_0_pspmc_0_psv_coresight_fpd_stm 0xf0b70000 0x10000>,
+                 <0xf0b80000 &versal_cips_0_pspmc_0_psv_coresight_fpd_atm 0xf0b80000 0x10000>,
+                 <0xf0c20000 &versal_cips_0_pspmc_0_psv_coresight_apu_fun 0xf0c20000 0x10000>,
+                 <0xf0c30000 &versal_cips_0_pspmc_0_psv_coresight_apu_etf 0xf0c30000 0x10000>,
+                 <0xf0c60000 &versal_cips_0_pspmc_0_psv_coresight_apu_ela 0xf0c60000 0x10000>,
+                 <0xf0ca0000 &versal_cips_0_pspmc_0_psv_coresight_apu_cti 0xf0ca0000 0x10000>,
+                 <0xf0d00000 &versal_cips_0_pspmc_0_psv_coresight_a720_dbg 0xf0d00000 0x10000>,
+                 <0xf0d10000 &versal_cips_0_pspmc_0_psv_coresight_a720_cti 0xf0d10000 0x10000>,
+                 <0xf0d20000 &versal_cips_0_pspmc_0_psv_coresight_a720_pmu 0xf0d20000 0x10000>,
+                 <0xf0d30000 &versal_cips_0_pspmc_0_psv_coresight_a720_etm 0xf0d30000 0x10000>,
+                 <0xf0d40000 &versal_cips_0_pspmc_0_psv_coresight_a721_dbg 0xf0d40000 0x10000>,
+                 <0xf0d50000 &versal_cips_0_pspmc_0_psv_coresight_a721_cti 0xf0d50000 0x10000>,
+                 <0xf0d60000 &versal_cips_0_pspmc_0_psv_coresight_a721_pmu 0xf0d60000 0x10000>,
+                 <0xf0d70000 &versal_cips_0_pspmc_0_psv_coresight_a721_etm 0xf0d70000 0x10000>,
+                 <0xf0f00000 &versal_cips_0_pspmc_0_psv_coresight_cpm_rom 0xf0f00000 0x10000>,
+                 <0xf0f20000 &versal_cips_0_pspmc_0_psv_coresight_cpm_fun 0xf0f20000 0x10000>,
+                 <0xf0f40000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a 0xf0f40000 0x10000>,
+                 <0xf0f50000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b 0xf0f50000 0x10000>,
+                 <0xf0f60000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c 0xf0f60000 0x10000>,
+                 <0xf0f70000 &versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d 0xf0f70000 0x10000>,
+                 <0xf0f80000 &versal_cips_0_pspmc_0_psv_coresight_cpm_atm 0xf0f80000 0x10000>,
+                 <0xf0fa0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a 0xf0fa0000 0x10000>,
+                 <0xf0fd0000 &versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d 0xf0fd0000 0x10000>,
+                 <0xf1000000 &i2c2 0xf1000000 0x10000>,
+                 <0xf1030000 &qspi 0xf1030000 0x10000>,
+                 <0xf1050000 &sdhci1 0xf1050000 0x10000>,
+                 <0xf1110000 &versal_cips_0_pspmc_0_psv_pmc_global_0 0xf1110000 0x50000>,
+                 <0xf11c0000 &dma0 0xf11c0000 0x10000>,
+                 <0xf11d0000 &dma1 0xf11d0000 0x10000>,
+                 <0xf11e0000 &versal_cips_0_pspmc_0_psv_pmc_aes 0xf11e0000 0x10000>,
+                 <0xf11f0000 &versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl 0xf11f0000 0x10000>,
+                 <0xf1200000 &versal_cips_0_pspmc_0_psv_pmc_rsa 0xf1200000 0x10000>,
+                 <0xf1210000 &versal_cips_0_pspmc_0_psv_pmc_sha 0xf1210000 0x10000>,
+                 <0xf1220000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot 0xf1220000 0x10000>,
+                 <0xf1230000 &versal_cips_0_pspmc_0_psv_pmc_trng 0xf1230000 0x10000>,
+                 <0xf1240000 &versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl 0xf1240000 0x10000>,
+                 <0xf1250000 &versal_cips_0_pspmc_0_psv_pmc_efuse_cache 0xf1250000 0x10000>,
+                 <0xf1260000 &versal_cips_0_pspmc_0_psv_crp_0 0xf1260000 0x10000>,
+                 <0xf1270000 &sysmon0 0xf1270000 0x30000>,
+                 <0xf12a0000 &rtc 0xf12a0000 0x10000>,
+                 <0xf12b0000 &versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 0xf12b0000 0x10000>,
+                 <0xf12d0000 &versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 0xf12d0000 0x1000>,
+                 <0xf12f0000 &pmc_xmpu 0xf12f0000 0x10000>,
+                 <0xf1300000 &pmc_xppu_npi 0xf1300000 0x10000>,
+                 <0xf1310000 &pmc_xppu 0xf1310000 0x10000>,
+                 <0xf2100000 &versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream 0xf2100000 0x10000>,
+                 <0xf6000000 &versal_cips_0_pspmc_0_psv_pmc_ram_npi 0xf6000000 0x2000000>,
+                 <0xfd000000 &cci 0xfd000000 0x100000>,
+                 <0xfd1a0000 &versal_cips_0_pspmc_0_psv_crf_0 0xfd1a0000 0x140000>,
+                 <0xfd360000 &versal_cips_0_pspmc_0_psv_fpd_afi_0 0xfd360000 0x10000>,
+                 <0xfd380000 &versal_cips_0_pspmc_0_psv_fpd_afi_2 0xfd380000 0x10000>,
+                 <0xfd390000 &fpd_xmpu 0xfd390000 0x10000>,
+                 <0xfd5c0000 &versal_cips_0_pspmc_0_psv_apu_0 0xfd5c0000 0x10000>,
+                 <0xfd5e0000 &versal_cips_0_pspmc_0_psv_fpd_cci_0 0xfd5e0000 0x10000>,
+                 <0xfd5f0000 &versal_cips_0_pspmc_0_psv_fpd_smmu_0 0xfd5f0000 0x10000>,
+                 <0xfd610000 &versal_cips_0_pspmc_0_psv_fpd_slcr_0 0xfd610000 0x10000>,
+                 <0xfd690000 &versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 0xfd690000 0x10000>,
+                 <0xfd700000 &versal_cips_0_pspmc_0_psv_fpd_gpv_0 0xfd700000 0x100000>,
+                 <0xfd800000 &smmu 0xfd800000 0x800000>,
+                 <0xfe200000 &dwc3_0 0xfe200000 0x100000>,
+                 <0xff000000 &serial0 0xff000000 0x10000>,
+                 <0xff030000 &i2c1 0xff030000 0x10000>,
+                 <0xff080000 &versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 0xff080000 0x20000>,
+                 <0xff0a0000 &versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 0xff0a0000 0x10000>,
+                 <0xff0b0000 &gpio0 0xff0b0000 0x10000>,
+                 <0xff0c0000 &gem0 0xff0c0000 0x10000>,
+                 <0xff0e0000 &ttc0 0xff0e0000 0x10000>,
+                 <0xff130000 &versal_cips_0_pspmc_0_psv_scntr_0 0xff130000 0x10000>,
+                 <0xff140000 &versal_cips_0_pspmc_0_psv_scntrs_0 0xff140000 0x10000>,
+                 <0xff410000 &versal_cips_0_pspmc_0_psv_lpd_slcr_0 0xff410000 0x100000>,
+                 <0xff510000 &versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 0xff510000 0x40000>,
+                 <0xff5e0000 &versal_cips_0_pspmc_0_psv_crl_0 0xff5e0000 0x300000>,
+                 <0xff960000 &versal_cips_0_pspmc_0_psv_ocm_ctrl 0xff960000 0x10000>,
+                 <0xff980000 &ocm_xmpu 0xff980000 0x10000>,
+                 <0xff990000 &lpd_xppu 0xff990000 0x10000>,
+                 <0xff9a0000 &versal_cips_0_pspmc_0_psv_rpu_0 0xff9a0000 0x10000>,
+                 <0xff9b0000 &versal_cips_0_pspmc_0_psv_lpd_afi_0 0xff9b0000 0x10000>,
+                 <0xff9d0000 &usb0 0xff9d0000 0x10000>,
+                 <0xffa80000 &lpd_dma_chan0 0xffa80000 0x10000>,
+                 <0xffa90000 &lpd_dma_chan1 0xffa90000 0x10000>,
+                 <0xffaa0000 &lpd_dma_chan2 0xffaa0000 0x10000>,
+                 <0xffab0000 &lpd_dma_chan3 0xffab0000 0x10000>,
+                 <0xffac0000 &lpd_dma_chan4 0xffac0000 0x10000>,
+                 <0xffad0000 &lpd_dma_chan5 0xffad0000 0x10000>,
+                 <0xffae0000 &lpd_dma_chan6 0xffae0000 0x10000>,
+                 <0xffaf0000 &lpd_dma_chan7 0xffaf0000 0x10000>,
+                 <0xffc90000 &versal_cips_0_pspmc_0_psv_psm_global_reg 0xffc90000 0xf000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_tcm_ram_0 0x0 0x40000>,
+                 <0xf9000000 &gic_r5 0xf9000000 0x3000>,
+                 <0xffe40000 &versal_cips_0_pspmc_0_psv_r5_0_instruction_cache 0xffe40000 0x10000>,
+                 <0xffe50000 &versal_cips_0_pspmc_0_psv_r5_0_data_cache 0xffe50000 0x10000>,
+                 <0xffec0000 &versal_cips_0_pspmc_0_psv_r5_1_instruction_cache 0xffec0000 0x10000>,
+                 <0xffed0000 &versal_cips_0_pspmc_0_psv_r5_1_data_cache 0xffed0000 0x10000>,
+                 <0x0 &versal_cips_0_pspmc_0_psv_r5_1_atcm 0x0 0x10000>,
+                 <0x20000 &versal_cips_0_pspmc_0_psv_r5_1_btcm 0x20000 0x10000>;
+                #ranges-address-cells = <0x1>;
+                #ranges-size-cells = <0x1>;
+                phandle = <0xa6>;
+
+                psv_cortexr5_1: cpu@1 {
+                        compatible = "arm,cortex-r5";
+                        device_type = "cpu";
+                        reg = <0x1>;
+                        operating-points-v2 = <&cpu_opp_table>;
+                        power-domains = <&versal_firmware 0x18110006>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,pss-ref-clk-freq = <0x1fc9f08>;
+                        xlnx,ip-name = "psv_cortexr5";
+                        access-val = <0xff>;
+                        bus-handle = <0x1>;
+                        xlnx,cpu-clk-freq-hz = <0x23c32ea3>;
+                        cpu-frequency = <0x23c32ea3>;
+                        phandle = <0xa7>;
+                };
+        };
+
+        cpu_opp_table: opp-table-cpu {
+                compatible = "operating-points-v2";
+                opp-shared;
+                phandle = <0x73>;
+
+                opp-1400000000 {
+                        opp-hz = <0x0 0x53724e00>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-700000000 {
+                        opp-hz = <0x0 0x29b92700>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-466666666 {
+                        opp-hz = <0x0 0x1bd0c4aa>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+
+                opp-350000000 {
+                        opp-hz = <0x0 0x14dc9380>;
+                        clock-latency-ns = <0x7a120>;
+                        opp-microvolt = <0xf4240>;
+                };
+        };
+
+        dcc: dcc {
+                compatible = "arm,dcc";
+                status = "disabled";
+                bootph-all;
+                phandle = <0xa8>;
+        };
+
+        fpga: fpga-region {
+                compatible = "fpga-region";
+                fpga-mgr = <&versal_fpga>;
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0xa9>;
+        };
+
+        psci: psci {
+                compatible = "arm,psci-0.2";
+                method = "smc";
+                phandle = <0xaa>;
+        };
+
+        pmu {
+                compatible = "arm,armv8-pmuv3";
+                interrupt-parent = <&imux>;
+                interrupts = <0x1 0x7 0x304>;
+        };
+
+        timer: timer {
+                compatible = "arm,armv8-timer";
+                interrupt-parent = <&imux>;
+                interrupts = <0x1 0xd 0x4 0x1 0xe 0x4 0x1 0xb 0x4 0x1 0xa 0x4>;
+                phandle = <0xab>;
+        };
+
+        versal_fpga: versal-fpga {
+                compatible = "xlnx,versal-fpga";
+                phandle = <0x8f>;
+        };
+
+        sensor0: versal-thermal-sensor {
+                compatible = "xlnx,versal-thermal";
+                #thermal-sensor-cells = <0x0>;
+                io-channels = <0x37>;
+                io-channel-names = "sysmon-temp-channel";
+                phandle = <0x91>;
+        };
+
+        thermal-zones {
+
+                versal_thermal: versal-thermal {
+                        polling-delay-passive = <0xfa>;
+                        polling-delay = <0x3e8>;
+                        thermal-sensors = <0x91>;
+                        phandle = <0xac>;
+
+                        trips {
+
+                                temp_alert: temp-alert {
+                                        temperature = <0x11170>;
+                                        hysteresis = <0x0>;
+                                        type = "passive";
+                                        phandle = <0xad>;
+                                };
+
+                                ot_crit: ot-crit {
+                                        temperature = <0x1e848>;
+                                        hysteresis = <0x0>;
+                                        type = "critical";
+                                        phandle = <0xae>;
+                                };
+                        };
+                };
+        };
+
+        amba_apu: apu-bus {
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&gic_a72>;
+                bootph-all;
+                phandle = <0x2>;
+
+                gic_a72: interrupt-controller@f9000000 {
+                        compatible = "arm,gic-v3";
+                        #interrupt-cells = <0x3>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        reg = <0x0 0xf9000000 0x0 0x80000 0x0 0xf9080000 0x0 0x80000>;
+                        interrupt-controller;
+                        interrupt-parent = <&gic_a72>;
+                        interrupts = <0x1 0x9 0x4>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,apu-gic-its-ctl = <0xf9020000>;
+                        xlnx,ip-name = "psv_acpu_gic";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_acpu_gic";
+                        phandle = <0x40>;
+
+                        gic_its: msi-controller@f9020000 {
+                                compatible = "arm,gic-v3-its";
+                                status = "okay";
+                                msi-controller;
+                                #msi-cells = <0x1>;
+                                reg = <0x0 0xf9020000 0x0 0x20000>;
+                                phandle = <0x4>;
+                        };
+                };
+        };
+
+        amba_rpu: rpu-bus {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&gic_r5>;
+                bootph-all;
+                phandle = <0x84>;
+
+                gic_r5: interrupt-controller@f9000000 {
+                        compatible = "arm,pl390";
+                        #interrupt-cells = <0x3>;
+                        interrupt-controller;
+                        status = "okay";
+                        reg = <0x0 0xf9000000 0x0 0x1000 0x0 0xf9001000 0x0 0x1000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_rcpu_gic";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_rcpu_gic";
+                        phandle = <0x88>;
+                };
+        };
+
+        amba: axi {
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                ranges;
+                interrupt-parent = <&imux>;
+                bootph-all;
+                phandle = <0x1>;
+
+                imux: interrupt-multiplex {
+                        compatible = "interrupt-multiplex";
+                        #address-cells = <0x0>;
+                        #interrupt-cells = <0x3>;
+                        interrupt-controller;
+                        interrupt-parent = <&gic_a72>,
+                         <&gic_r5>;
+                        interrupt-map-mask = <0x0 0xffff 0x0>;
+                        interrupt-map = <0x0 0x14 0x0 &gic_a72 0x0 0x14 0x1>,
+                         <0x0 0x15 0x0 &gic_a72 0x0 0x15 0x1>,
+                         <0x0 0x6a 0x0 &gic_a72 0x0 0x6a 0x4>,
+                         <0x0 0x3c 0x0 &gic_a72 0x0 0x3c 0x4>,
+                         <0x0 0x3d 0x0 &gic_a72 0x0 0x3d 0x4>,
+                         <0x0 0x3e 0x0 &gic_a72 0x0 0x3e 0x4>,
+                         <0x0 0x3f 0x0 &gic_a72 0x0 0x3f 0x4>,
+                         <0x0 0x40 0x0 &gic_a72 0x0 0x40 0x4>,
+                         <0x0 0x41 0x0 &gic_a72 0x0 0x41 0x4>,
+                         <0x0 0x42 0x0 &gic_a72 0x0 0x42 0x4>,
+                         <0x0 0x43 0x0 &gic_a72 0x0 0x43 0x4>,
+                         <0x0 0x38 0x0 &gic_a72 0x0 0x38 0x4>,
+                         <0x0 0x3a 0x0 &gic_a72 0x0 0x3a 0x4>,
+                         <0x0 0xd 0x0 &gic_a72 0x0 0xd 0x4>,
+                         <0x0 0x7a 0x0 &gic_a72 0x0 0x7a 0x4>,
+                         <0x0 0xe 0x0 &gic_a72 0x0 0xe 0x4>,
+                         <0x0 0xf 0x0 &gic_a72 0x0 0xf 0x4>,
+                         <0x0 0x8e 0x0 &gic_a72 0x0 0x8e 0x4>,
+                         <0x0 0x8f 0x0 &gic_a72 0x0 0x8f 0x4>,
+                         <0x0 0x7e 0x0 &gic_a72 0x0 0x7e 0x4>,
+                         <0x0 0x80 0x0 &gic_a72 0x0 0x80 0x4>,
+                         <0x0 0x12 0x0 &gic_a72 0x0 0x12 0x4>,
+                         <0x0 0x13 0x0 &gic_a72 0x0 0x13 0x4>,
+                         <0x0 0x6b 0x0 &gic_a72 0x0 0x6b 0x4>,
+                         <0x0 0x7c 0x0 &gic_a72 0x0 0x7c 0x4>,
+                         <0x0 0x7d 0x0 &gic_a72 0x0 0x7d 0x4>,
+                         <0x0 0x10 0x0 &gic_a72 0x0 0x10 0x4>,
+                         <0x0 0x11 0x0 &gic_a72 0x0 0x11 0x4>,
+                         <0x0 0x16 0x0 &gic_a72 0x0 0x16 0x4>,
+                         <0x0 0x1a 0x0 &gic_a72 0x0 0x1a 0x4>,
+                         <0x0 0x4a 0x0 &gic_a72 0x0 0x4a 0x4>,
+                         <0x0 0x48 0x0 &gic_a72 0x0 0x48 0x4>,
+                         <0x0 0x1e 0x0 &gic_a72 0x0 0x1e 0x4>,
+                         <0x0 0x1f 0x0 &gic_a72 0x0 0x1f 0x4>,
+                         <0x0 0x83 0x0 &gic_a72 0x0 0x83 0x4>,
+                         <0x0 0x84 0x0 &gic_a72 0x0 0x84 0x4>,
+                         <0x0 0x14 0x0 &gic_r5 0x0 0x14 0x1>,
+                         <0x0 0x15 0x0 &gic_r5 0x0 0x15 0x1>,
+                         <0x0 0x6a 0x0 &gic_r5 0x0 0x6a 0x4>,
+                         <0x0 0x3c 0x0 &gic_r5 0x0 0x3c 0x4>,
+                         <0x0 0x3d 0x0 &gic_r5 0x0 0x3d 0x4>,
+                         <0x0 0x3e 0x0 &gic_r5 0x0 0x3e 0x4>,
+                         <0x0 0x3f 0x0 &gic_r5 0x0 0x3f 0x4>,
+                         <0x0 0x40 0x0 &gic_r5 0x0 0x40 0x4>,
+                         <0x0 0x41 0x0 &gic_r5 0x0 0x41 0x4>,
+                         <0x0 0x42 0x0 &gic_r5 0x0 0x42 0x4>,
+                         <0x0 0x43 0x0 &gic_r5 0x0 0x43 0x4>,
+                         <0x0 0x38 0x0 &gic_r5 0x0 0x38 0x4>,
+                         <0x0 0x3a 0x0 &gic_r5 0x0 0x3a 0x4>,
+                         <0x0 0xd 0x0 &gic_r5 0x0 0xd 0x4>,
+                         <0x0 0x7a 0x0 &gic_r5 0x0 0x7a 0x4>,
+                         <0x0 0xe 0x0 &gic_r5 0x0 0xe 0x4>,
+                         <0x0 0xf 0x0 &gic_r5 0x0 0xf 0x4>,
+                         <0x0 0x8e 0x0 &gic_r5 0x0 0x8e 0x4>,
+                         <0x0 0x8f 0x0 &gic_r5 0x0 0x8f 0x4>,
+                         <0x0 0x7e 0x0 &gic_r5 0x0 0x7e 0x4>,
+                         <0x0 0x80 0x0 &gic_r5 0x0 0x80 0x4>,
+                         <0x0 0x12 0x0 &gic_r5 0x0 0x12 0x4>,
+                         <0x0 0x13 0x0 &gic_r5 0x0 0x13 0x4>,
+                         <0x0 0x6b 0x0 &gic_r5 0x0 0x6b 0x4>,
+                         <0x0 0x7c 0x0 &gic_r5 0x0 0x7c 0x4>,
+                         <0x0 0x7d 0x0 &gic_r5 0x0 0x7d 0x4>,
+                         <0x0 0x10 0x0 &gic_r5 0x0 0x10 0x4>,
+                         <0x0 0x11 0x0 &gic_r5 0x0 0x11 0x4>,
+                         <0x0 0x16 0x0 &gic_r5 0x0 0x16 0x4>,
+                         <0x0 0x1a 0x0 &gic_r5 0x0 0x1a 0x4>,
+                         <0x0 0x4a 0x0 &gic_r5 0x0 0x4a 0x4>,
+                         <0x0 0x48 0x0 &gic_r5 0x0 0x48 0x4>,
+                         <0x0 0x1e 0x0 &gic_r5 0x0 0x1e 0x4>,
+                         <0x0 0x1f 0x0 &gic_r5 0x0 0x1f 0x4>,
+                         <0x0 0x83 0x0 &gic_r5 0x0 0x83 0x4>,
+                         <0x0 0x84 0x0 &gic_r5 0x0 0x84 0x4>;
+                        phandle = <0x90>;
+                };
+
+                can0: can@ff060000 {
+                        compatible = "xlnx,canfd-2.0";
+                        status = "disabled";
+                        reg = <0x0 0xff060000 0x0 0x6000>;
+                        interrupts = <0x0 0x14 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "can_clk", "s_axi_aclk";
+                        rx-fifo-depth = <0x40>;
+                        tx-mailbox-count = <0x20>;
+                        clocks = <&can0_clk>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401f>;
+                        phandle = <0xaf>;
+                };
+
+                can1: can@ff070000 {
+                        compatible = "xlnx,canfd-2.0";
+                        status = "disabled";
+                        reg = <0x0 0xff070000 0x0 0x6000>;
+                        interrupts = <0x0 0x15 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "can_clk", "s_axi_aclk";
+                        rx-fifo-depth = <0x40>;
+                        tx-mailbox-count = <0x20>;
+                        clocks = <&can1_clk>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224020>;
+                        phandle = <0xb0>;
+                };
+
+                cci: cci@fd000000 {
+                        compatible = "arm,cci-500";
+                        status = "okay";
+                        reg = <0x0 0xfd000000 0x0 0x10000>;
+                        ranges = <0x0 0x0 0xfd000000 0xa0000>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x1>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_fpd_maincci";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_maincci_0";
+                        phandle = <0x42>;
+
+                        cci_pmu: pmu@10000 {
+                                compatible = "arm,cci-500-pmu,r0";
+                                reg = <0x10000 0x90000>;
+                                interrupt-parent = <&imux>;
+                                interrupts = <0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4 0x0 0x6a 0x4>;
+                                phandle = <0xb1>;
+                        };
+                };
+
+                lpd_dma_chan0: dma-controller@ffa80000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffa80000 0x0 0x1000>;
+                        interrupts = <0x0 0x3c 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224035>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_0";
+                        phandle = <0x61>;
+                };
+
+                lpd_dma_chan1: dma-controller@ffa90000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffa90000 0x0 0x1000>;
+                        interrupts = <0x0 0x3d 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224036>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_1";
+                        phandle = <0x62>;
+                };
+
+                lpd_dma_chan2: dma-controller@ffaa0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffaa0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3e 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224037>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_2";
+                        phandle = <0x63>;
+                };
+
+                lpd_dma_chan3: dma-controller@ffab0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffab0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3f 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224038>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_3";
+                        phandle = <0x64>;
+                };
+
+                lpd_dma_chan4: dma-controller@ffac0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffac0000 0x0 0x1000>;
+                        interrupts = <0x0 0x40 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224039>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_4";
+                        phandle = <0x65>;
+                };
+
+                lpd_dma_chan5: dma-controller@ffad0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffad0000 0x0 0x1000>;
+                        interrupts = <0x0 0x41 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403a>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_5";
+                        phandle = <0x66>;
+                };
+
+                lpd_dma_chan6: dma-controller@ffae0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffae0000 0x0 0x1000>;
+                        interrupts = <0x0 0x42 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403b>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_6";
+                        phandle = <0x67>;
+                };
+
+                lpd_dma_chan7: dma-controller@ffaf0000 {
+                        compatible = "xlnx,zynqmp-dma-1.0";
+                        status = "okay";
+                        reg = <0x0 0xffaf0000 0x0 0x1000>;
+                        interrupts = <0x0 0x43 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_main", "clk_apb";
+                        xlnx,dma-type = <0x1>;
+                        #dma-cells = <0x1>;
+                        xlnx,bus-width = <0x40>;
+                        clocks = <&versal_clk 0x51>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822403c>;
+                        xlnx,rable = <0x0>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,ip-name = "psv_adma";
+                        xlnx,dma-mode = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_adma_7";
+                        phandle = <0x68>;
+                };
+
+                gem0: ethernet@ff0c0000 {
+                        compatible = "xlnx,versal-gem", "cdns,gem";
+                        status = "okay";
+                        reg = <0x0 0xff0c0000 0x0 0x1000>;
+                        interrupts = <0x0 0x38 0x4 0x0 0x38 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x52>,
+                         <&versal_clk 0x58>,
+                         <&versal_clk 0x31>,
+                         <&versal_clk 0x30>,
+                         <&versal_clk 0x2b>;
+                        power-domains = <&versal_firmware 0x18224019>;
+                        xlnx,has-mdio = <0x1>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,gem-board-interface = "custom";
+                        phy-mode = "rgmii-id";
+                        xlnx,enet-slcr-1000mbps-div0 = <0x2>;
+                        xlnx,enet-slcr-10mbps-div0 = <0x64>;
+                        xlnx,rable = <0x0>;
+                        xlnx,enet-tsu-clk-freq-hz = <0xee6a8ba>;
+                        xlnx,ip-name = "psv_ethernet";
+                        xlnx,eth-mode = <0x1>;
+                        xlnx,enet-clk-freq-hz = <0x773545d>;
+                        xlnx,enet-slcr-100mbps-div0 = <0xa>;
+                        local-mac-address = [00 0A 23 00 00 00];
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ethernet_0";
+                        phy-handle = <0x94>;
+                        phandle = <0x54>;
+
+                        mdio: mdio {
+                                #address-cells = <0x1>;
+                                #size-cells = <0x0>;
+                                phandle = <0xb2>;
+
+                                phy1: ethernet-phy@1 {
+                                        #phy-cells = <0x1>;
+                                        compatible = "ethernet-phy-id2000.a231";
+                                        reg = <0x1>;
+                                        ti,rx-internal-delay = <0xb>;
+                                        ti,tx-internal-delay = <0xa>;
+                                        ti,fifo-depth = <0x1>;
+                                        ti,dp83867-rxctrl-strap-quirk;
+                                        reset-assert-us = <0x64>;
+                                        reset-deassert-us = <0x118>;
+                                        reset-gpios = <&gpio1 0x30 0x1>;
+                                        phandle = <0x94>;
+                                };
+
+                                phy2: ethernet-phy@2 {
+                                        #phy-cells = <0x1>;
+                                        compatible = "ethernet-phy-id2000.a231";
+                                        reg = <0x2>;
+                                        ti,rx-internal-delay = <0xb>;
+                                        ti,tx-internal-delay = <0xa>;
+                                        ti,fifo-depth = <0x1>;
+                                        ti,dp83867-rxctrl-strap-quirk;
+                                        reset-assert-us = <0x64>;
+                                        reset-deassert-us = <0x118>;
+                                        reset-gpios = <&gpio1 0x31 0x1>;
+                                        phandle = <0x96>;
+                                };
+                        };
+                };
+
+                gem1: ethernet@ff0d0000 {
+                        compatible = "xlnx,versal-gem", "cdns,gem";
+                        status = "disabled";
+                        reg = <0x0 0xff0d0000 0x0 0x1000>;
+                        interrupts = <0x0 0x3a 0x4 0x0 0x3a 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x52>,
+                         <&versal_clk 0x59>,
+                         <&versal_clk 0x33>,
+                         <&versal_clk 0x32>,
+                         <&versal_clk 0x2b>;
+                        power-domains = <&versal_firmware 0x1822401a>;
+                        phy-handle = <0x96>;
+                        phy-mode = "rgmii-id";
+                        phandle = <0xb3>;
+                };
+
+                gpio0: gpio@ff0b0000 {
+                        compatible = "xlnx,versal-gpio-1.0";
+                        status = "okay";
+                        reg = <0x0 0xff0b0000 0x0 0x1000>;
+                        interrupts = <0x0 0xd 0x4>;
+                        interrupt-parent = <&imux>;
+                        #gpio-cells = <0x2>;
+                        gpio-controller;
+                        #interrupt-cells = <0x2>;
+                        interrupt-controller;
+                        clocks = <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224023>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_gpio";
+                        emio-gpio-width = [00];
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_gpio_2";
+                        phandle = <0x53>;
+                };
+
+                gpio1: gpio@f1020000 {
+                        compatible = "xlnx,pmc-gpio-1.0";
+                        status = "disabled";
+                        reg = <0x0 0xf1020000 0x0 0x1000>;
+                        interrupts = <0x0 0x7a 0x4>;
+                        interrupt-parent = <&imux>;
+                        #gpio-cells = <0x2>;
+                        gpio-controller;
+                        #interrupt-cells = <0x2>;
+                        interrupt-controller;
+                        clocks = <&versal_clk 0x3d>;
+                        power-domains = <&versal_firmware 0x1822402c>;
+                        phandle = <0x95>;
+                };
+
+                i2c0: i2c@ff020000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "disabled";
+                        reg = <0x0 0xff020000 0x0 0x1000>;
+                        interrupts = <0x0 0xe 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x62>;
+                        power-domains = <&versal_firmware 0x1822401d>;
+                        phandle = <0xb4>;
+                };
+
+                i2c1: i2c@ff030000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "okay";
+                        reg = <0x0 0xff030000 0x0 0x1000>;
+                        interrupts = <0x0 0xf 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x63>;
+                        power-domains = <&versal_firmware 0x1822401e>;
+                        xlnx,rable = <0x0>;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,i2c-clk-freq-hz = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_i2c";
+                        xlnx,iic-board-interface = "custom";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_i2c_1";
+                        phandle = <0x50>;
+                };
+
+                i2c2: i2c@f1000000 {
+                        compatible = "cdns,i2c-r1p14";
+                        status = "okay";
+                        reg = <0x0 0xf1000000 0x0 0x1000>;
+                        interrupts = <0x0 0x7b 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-frequency = <0x186a0>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x3e>;
+                        power-domains = <&versal_firmware 0x1822402d>;
+                        xlnx,rable = <0x0>;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,i2c-clk-freq-hz = <0x5f5dd19>;
+                        xlnx,ip-name = "psv_pmc_i2c";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_i2c_0";
+                        phandle = <0x28>;
+                };
+
+                mc0: memory-controller@f6150000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "okay";
+                        reg = <0x0 0xf6150000 0x0 0x2000 0x0 0xf6070000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        ranges = <0x0 0x0 0x0 0x80000000 0x0 0x40000 0x0 0x7ffc0000>;
+                        phandle = <0xb5>;
+                };
+
+                mc1: memory-controller@f62c0000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf62c0000 0x0 0x2000 0x0 0xf6210000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb6>;
+                };
+
+                mc2: memory-controller@f6430000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf6430000 0x0 0x2000 0x0 0xf6380000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb7>;
+                };
+
+                mc3: memory-controller@f65a0000 {
+                        compatible = "xlnx,versal-ddrmc";
+                        status = "disabled";
+                        reg = <0x0 0xf65a0000 0x0 0x2000 0x0 0xf64f0000 0x0 0x20000>;
+                        reg-names = "base", "noc";
+                        interrupts = <0x0 0x93 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb8>;
+                };
+
+                ocm: memory-controller@ff960000 {
+                        compatible = "xlnx,zynqmp-ocmc-1.0";
+                        reg = <0x0 0xff960000 0x0 0x1000>;
+                        interrupts = <0x0 0xa 0x4>;
+                        interrupt-parent = <&imux>;
+                        phandle = <0xb9>;
+                };
+
+                rtc: rtc@f12a0000 {
+                        compatible = "xlnx,zynqmp-rtc";
+                        status = "okay";
+                        reg = <0x0 0xf12a0000 0x0 0x100>;
+                        interrupt-names = "alarm", "sec";
+                        interrupts = <0x0 0x8e 0x4 0x0 0x8f 0x4>;
+                        interrupt-parent = <&imux>;
+                        calibration = <0x7fff>;
+                        power-domains = <&versal_firmware 0x18224034>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_rtc";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_rtc_0";
+                        phandle = <0x38>;
+                };
+
+                sdhci0: mmc@f1040000 {
+                        compatible = "xlnx,versal-8.9a", "arasan,sdhci-8.9a";
+                        status = "disabled";
+                        reg = <0x0 0xf1040000 0x0 0x10000>;
+                        interrupts = <0x0 0x7e 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_xin", "clk_ahb", "gate";
+                        #clock-cells = <0x1>;
+                        clock-output-names = "clk_out_sd0", "clk_in_sd0";
+                        clocks = <&versal_clk 0x3b>,
+                         <&versal_clk 0x52>,
+                         <&versal_clk 0x4a>;
+                        power-domains = <&versal_firmware 0x1822402e>;
+                        phandle = <0xba>;
+                };
+
+                sdhci1: mmc@f1050000 {
+                        compatible = "xlnx,versal-8.9a", "arasan,sdhci-8.9a";
+                        status = "okay";
+                        reg = <0x0 0xf1050000 0x0 0x10000>;
+                        interrupts = <0x0 0x80 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "clk_xin", "clk_ahb", "gate";
+                        #clock-cells = <0x1>;
+                        clock-output-names = "clk_out_sd1", "clk_in_sd1";
+                        clocks = <&versal_clk 0x3c>,
+                         <&versal_clk 0x52>,
+                         <&versal_clk 0x4a>;
+                        power-domains = <&versal_firmware 0x1822402f>;
+                        xlnx,sd-board-interface = "custom";
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,clk-50-ddr-otap-dly = <0x0>;
+                        xlnx,clk-50-sdr-itap-dly = <0x2c>;
+                        xlnx,has-emio = <0x0>;
+                        clock-frequency = <0xbebba31>;
+                        xlnx,clk-100-sdr-otap-dly = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,mio-bank = <0x1>;
+                        xlnx,ip-name = "psv_pmc_sd";
+                        xlnx,bus-width = <0x8>;
+                        xlnx,card-detect = <0x0>;
+                        xlnx,has-wp = <0x0>;
+                        xlnx,has-cd = <0x0>;
+                        xlnx,slot-type = <0x3>;
+                        xlnx,clk-50-sdr-otap-dly = <0x4>;
+                        xlnx,clk-50-ddr-itap-dly = <0x0>;
+                        xlnx,has-power = <0x0>;
+                        xlnx,clk-200-sdr-otap-dly = <0x0>;
+                        xlnx,sdio-clk-freq-hz = <0xbebba31>;
+                        xlnx,write-protect = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_sd_1";
+                        no-1-8-v;
+                        phandle = <0x2a>;
+                };
+
+                serial0: serial@ff000000 {
+                        compatible = "arm,pl011", "arm,primecell";
+                        status = "okay";
+                        reg = <0x0 0xff000000 0x0 0x1000>;
+                        interrupts = <0x0 0x12 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg-io-width = <0x4>;
+                        clock-names = "uartclk", "apb_pclk";
+                        bootph-all;
+                        clocks = <&versal_clk 0x5c>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224021>;
+                        xlnx,has-modem = <0x0>;
+                        xlnx,uart-clk-freq-hz = <0x5f5dd19>;
+                        port-number = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_sbsauart";
+                        xlnx,uart-board-interface = "custom";
+                        xlnx,baudrate = <0x1c200>;
+                        cts-override;
+                        u-boot,dm-pre-reloc;
+                        xlnx,clock-freq = <0x5f5dd19>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_sbsauart_0";
+                        phandle = <0x4f>;
+                };
+
+                serial1: serial@ff010000 {
+                        compatible = "arm,pl011", "arm,primecell";
+                        status = "disabled";
+                        reg = <0x0 0xff010000 0x0 0x1000>;
+                        interrupts = <0x0 0x13 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg-io-width = <0x4>;
+                        clock-names = "uartclk", "apb_pclk";
+                        bootph-all;
+                        clocks = <&versal_clk 0x5d>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224022>;
+                        phandle = <0xbb>;
+                };
+
+                smmu: iommu@fd800000 {
+                        compatible = "arm,mmu-500";
+                        status = "okay";
+                        reg = <0x0 0xfd800000 0x0 0x40000>;
+                        stream-match-mask = <0x7c00>;
+                        #iommu-cells = <0x1>;
+                        #global-interrupts = <0x1>;
+                        interrupts = <0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4 0x0 0x6b 0x4>;
+                        interrupt-parent = <&imux>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_fpd_smmutcu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_smmutcu_0";
+                        phandle = <0x4d>;
+                };
+
+                ospi: spi@f1010000 {
+                        compatible = "xlnx,versal-ospi-1.0", "cdns,qspi-nor";
+                        status = "disabled";
+                        reg = <0x0 0xf1010000 0x0 0x10000 0x0 0xc0000000 0x0 0x20000000>;
+                        interrupts = <0x0 0x7c 0x4>;
+                        interrupt-parent = <&imux>;
+                        cdns,fifo-depth = <0x100>;
+                        cdns,fifo-width = <0x4>;
+                        cdns,is-dma = <0x1>;
+                        cdns,trigger-address = <0xc0000000>;
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x3a>;
+                        power-domains = <&versal_firmware 0x1822402a>;
+                        reset-names = "qspi";
+                        resets = <&versal_reset 0xc10402e>;
+                        phandle = <0xbc>;
+                };
+
+                qspi: spi@f1030000 {
+                        compatible = "xlnx,versal-qspi-1.0";
+                        status = "okay";
+                        reg = <0x0 0xf1030000 0x0 0x1000>;
+                        interrupts = <0x0 0x7d 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x39>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822402b>;
+                        xlnx,is-cache-coherent = <0x0>;
+                        xlnx,baud-rate-div = <0x8>;
+                        num-cs = <0x2>;
+                        xlnx,qspi-clk-freq-hz = <0x11e19751>;
+                        xlnx,rable = <0x0>;
+                        xlnx,bus-width = <0x2>;
+                        xlnx,ip-name = "psv_pmc_qspi";
+                        spi-rx-bus-width = <0x4>;
+                        xlnx,connection-mode = <0x2>;
+                        spi-tx-bus-width = <0x4>;
+                        qspi-fbclk = <0x1>;
+                        xlnx,clock-freq = <0x11e19751>;
+                        xlnx,qspi-baud-rate-div = <0x8>;
+                        xlnx,qspi-mode = <0x2>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_qspi_0";
+                        xlnx,qspi-bus-width = <0x2>;
+                        is-dual = <0x1>;
+                        phandle = <0x29>;
+                };
+
+                spi0: spi@ff040000 {
+                        compatible = "cdns,spi-r1p6";
+                        status = "disabled";
+                        reg = <0x0 0xff040000 0x0 0x1000>;
+                        interrupts = <0x0 0x10 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x5e>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401b>;
+                        phandle = <0xbd>;
+                };
+
+                spi1: spi@ff050000 {
+                        compatible = "cdns,spi-r1p6";
+                        status = "disabled";
+                        reg = <0x0 0xff050000 0x0 0x1000>;
+                        interrupts = <0x0 0x11 0x4>;
+                        interrupt-parent = <&imux>;
+                        clock-names = "ref_clk", "pclk";
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        clocks = <&versal_clk 0x5f>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x1822401c>;
+                        phandle = <0xbe>;
+                };
+
+                sysmon0: sysmon@f1270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        #io-channel-cells = <0x0>;
+                        reg = <0x0 0xf1270000 0x0 0x4000>;
+                        interrupts = <0x0 0x90 0x4>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        xlnx,nodeid = <0x18224055>;
+                        xlnx,sat-63-desc = "PS , FPD , satellite";
+                        xlnx,sat-34-y = <0x34f8>;
+                        xlnx,sat-17-x = <0x5842>;
+                        xlnx,sat-1-desc = "PMC , system , ADC";
+                        xlnx,sat-9-x = <0x4999>;
+                        xlnx,sat-17-y = <0x1dc4>;
+                        xlnx,sat-19-desc = "Clocking , column , satellite";
+                        xlnx,sat-20-desc = "Clocking , column , satellite";
+                        xlnx,sat-9-y = <0x25ed>;
+                        xlnx,sat-38-x = <0xae9>;
+                        xlnx,sat-38-y = <0x2ff0>;
+                        xlnx,sat-32-desc = "VNOC , satellite";
+                        xlnx,rable = <0x0>;
+                        xlnx,sat-22-x = <0x3a6a>;
+                        xlnx,ip-name = "psv_pmc_sysmon";
+                        xlnx,sat-22-y = <0x19f9>;
+                        xlnx,sat-16-desc = "Clocking , column , satellite";
+                        xlnx,sat-9-desc = "VNOC , satellite";
+                        xlnx,sat-26-x = <0x2b3b>;
+                        xlnx,sat-28-desc = "VNOC , satellite";
+                        xlnx,sat-26-y = <0xe06>;
+                        xlnx,sat-10-x = <0x48b8>;
+                        xlnx,sat-64-x = <0xc>;
+                        xlnx,sat-2-x = <0xc>;
+                        xlnx,sat-10-y = <0x34f8>;
+                        xlnx,sat-64-y = <0xb34>;
+                        xlnx,sat-2-y = <0xb34>;
+                        xlnx,sat-13-desc = "ME , satellite";
+                        xlnx,sat-41-desc = "Clocking , column , satellite";
+                        xlnx,sat-31-x = <0x1c0c>;
+                        xlnx,sat-6-desc = "XPIO , satellite";
+                        xlnx,sat-31-y = <0xe06>;
+                        xlnx,sat-14-x = <0x5842>;
+                        xlnx,sat-6-x = <0x5833>;
+                        xlnx,sat-25-desc = "ME , satellite";
+                        xlnx,sat-14-y = <0x2ff0>;
+                        xlnx,sat-6-y = <0x5ff>;
+                        xlnx,sat-35-x = <0x123a>;
+                        xlnx,sat-10-desc = "ME , satellite";
+                        xlnx,sat-37-desc = "ME , satellite";
+                        xlnx,sat-35-y = <0x34f8>;
+                        xlnx,sat-18-x = <0x5842>;
+                        xlnx,sat-3-desc = "XPIO , satellite";
+                        xlnx,sat-18-y = <0x1795>;
+                        xlnx,sat-22-desc = "VNOC , satellite";
+                        xlnx,sat-40-x = <0xae9>;
+                        xlnx,sat-39-x = <0xae9>;
+                        xlnx,sat-40-y = <0x2389>;
+                        xlnx,sat-39-y = <0x29b7>;
+                        xlnx,sat-23-x = <0x3a6a>;
+                        xlnx,sat-34-desc = "ME , satellite";
+                        xlnx,sat-23-y = <0x25ed>;
+                        xlnx,sat-18-desc = "Clocking , column , satellite";
+                        xlnx,sat-27-x = <0x2b3b>;
+                        xlnx,sat-27-y = <0x19f9>;
+                        xlnx,sat-11-x = <0x40ef>;
+                        xlnx,sat-3-x = <0x1153>;
+                        xlnx,sat-31-desc = "VNOC , satellite";
+                        xlnx,sat-11-y = <0x34f8>;
+                        xlnx,sat-3-y = <0x5ff>;
+                        status = "okay";
+                        xlnx,sat-32-x = <0x1c0c>;
+                        xlnx,sat-15-desc = "Clocking , column , satellite";
+                        xlnx,sat-32-y = <0x19f9>;
+                        xlnx,sat-15-x = <0x5842>;
+                        xlnx,sat-8-desc = "VNOC , satellite";
+                        xlnx,sat-7-x = <0x4999>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_sysmon_0";
+                        xlnx,sat-15-y = <0x29b7>;
+                        xlnx,sat-7-y = <0xe06>;
+                        xlnx,sat-27-desc = "VNOC , satellite";
+                        xlnx,sat-36-x = <0xa71>;
+                        xlnx,sat-36-y = <0x34f8>;
+                        xlnx,sat-12-desc = "ME , satellite";
+                        xlnx,sat-19-x = <0x5842>;
+                        xlnx,sat-20-x = <0x5842>;
+                        xlnx,sat-40-desc = "Clocking , column , satellite";
+                        xlnx,sat-39-desc = "Clocking , column , satellite";
+                        xlnx,sat-19-y = <0x11d0>;
+                        xlnx,sat-20-y = <0xba1>;
+                        xlnx,sat-5-desc = "XPIO , satellite";
+                        xlnx,sat-41-x = <0xae9>;
+                        xlnx,sat-24-desc = "ME , satellite";
+                        xlnx,sat-41-y = <0x1dc4>;
+                        xlnx,sat-24-x = <0x3926>;
+                        xlnx,sat-24-y = <0x34f8>;
+                        xlnx,sat-36-desc = "ME , satellite";
+                        xlnx,sat-64-desc = "PS , LPD , satellite";
+                        xlnx,sat-2-desc = "PMC , user , ADC";
+                        xlnx,sat-28-x = <0x2b3b>;
+                        xlnx,sat-21-desc = "VNOC , satellite";
+                        xlnx,sat-28-y = <0x25ed>;
+                        xlnx,sat-12-x = <0x5081>;
+                        xlnx,sat-4-x = <0x28f3>;
+                        xlnx,sat-12-y = <0x34f8>;
+                        xlnx,sat-4-y = <0x5ff>;
+                        xlnx,sat-33-desc = "VNOC , satellite";
+                        xlnx,sat-33-x = <0x1c0c>;
+                        xlnx,sat-33-y = <0x25ed>;
+                        xlnx,sat-16-x = <0x5842>;
+                        xlnx,sat-17-desc = "Clocking , column , satellite";
+                        xlnx,sat-8-x = <0x4999>;
+                        xlnx,sat-16-y = <0x2389>;
+                        xlnx,sat-8-y = <0x19f9>;
+                        xlnx,sat-37-x = <0x2a8>;
+                        xlnx,sat-30-desc = "ME , satellite";
+                        xlnx,sat-29-desc = "ME , satellite";
+                        xlnx,sat-37-y = <0x34f8>;
+                        xlnx,sat-21-x = <0x3a6a>;
+                        xlnx,sat-14-desc = "Clocking , column , satellite";
+                        xlnx,sat-21-y = <0xe06>;
+                        xlnx,sat-7-desc = "VNOC , satellite";
+                        xlnx,sat-26-desc = "VNOC , satellite";
+                        xlnx,sat-25-x = <0x315e>;
+                        xlnx,sat-25-y = <0x34f8>;
+                        xlnx,sat-63-x = <0xc>;
+                        xlnx,sat-11-desc = "ME , satellite";
+                        xlnx,sat-1-x = <0xc>;
+                        xlnx,sat-63-y = <0xb34>;
+                        xlnx,sat-38-desc = "Clocking , column , satellite";
+                        xlnx,sat-1-y = <0xb34>;
+                        xlnx,sat-4-desc = "XPIO , satellite";
+                        xlnx,sat-30-x = <0x21cc>;
+                        xlnx,sat-29-x = <0x2995>;
+                        xlnx,sat-30-y = <0x34f8>;
+                        xlnx,sat-29-y = <0x34f8>;
+                        xlnx,sat-13-x = <0x584a>;
+                        xlnx,sat-23-desc = "VNOC , satellite";
+                        xlnx,sat-5-x = <0x4093>;
+                        xlnx,sat-13-y = <0x34f8>;
+                        xlnx,sat-5-y = <0x5ff>;
+                        xlnx,sat-35-desc = "ME , satellite";
+                        xlnx,sat-34-x = <0x1a03>;
+                        phandle = <0x37>;
+                };
+
+                sysmon1: sysmon@109270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x9270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18225055>;
+                        phandle = <0xbf>;
+                };
+
+                sysmon2: sysmon@111270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x11270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18226055>;
+                        phandle = <0xc0>;
+                };
+
+                sysmon3: sysmon@119270000 {
+                        compatible = "xlnx,versal-sysmon";
+                        status = "disabled";
+                        reg = <0x1 0x19270000 0x0 0x4000>;
+                        xlnx,numchannels = [00];
+                        #address-cells = <0x1>;
+                        #size-cells = <0x0>;
+                        xlnx,nodeid = <0x18227055>;
+                        phandle = <0xc1>;
+                };
+
+                ttc0: timer@ff0e0000 {
+                        compatible = "cdns,ttc";
+                        status = "okay";
+                        interrupts = <0x0 0x25 0x4 0x0 0x26 0x4 0x0 0x27 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff0e0000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x27>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224024>;
+                        xlnx,ttc-clk2-clksrc = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_ttc";
+                        xlnx,ttc-clk1-clksrc = <0x0>;
+                        xlnx,ttc-clk0-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-clk1-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-clk2-freq-hz = <0x8f0cba9>;
+                        xlnx,ttc-board-interface = "custom";
+                        xlnx,clock-freq = <0x8f0cba9>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ttc_0";
+                        xlnx,ttc-clk0-clksrc = <0x0>;
+                        phandle = <0x55>;
+                };
+
+                ttc1: timer@ff0f0000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x28 0x4 0x0 0x29 0x4 0x0 0x2a 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff0f0000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x28>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224025>;
+                        phandle = <0xc2>;
+                };
+
+                ttc2: timer@ff100000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x2b 0x4 0x0 0x2c 0x4 0x0 0x2d 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff100000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x29>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224026>;
+                        phandle = <0xc3>;
+                };
+
+                ttc3: timer@ff110000 {
+                        compatible = "cdns,ttc";
+                        status = "disabled";
+                        interrupts = <0x0 0x2e 0x4 0x0 0x2f 0x4 0x0 0x30 0x4>;
+                        interrupt-parent = <&imux>;
+                        reg = <0x0 0xff110000 0x0 0x1000>;
+                        timer-width = <0x20>;
+                        clocks = <&versal_clk 0x2a>,
+                         <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224027>;
+                        phandle = <0xc4>;
+                };
+
+                usb0: usb@ff9d0000 {
+                        compatible = "xlnx,versal-dwc3";
+                        status = "okay";
+                        reg = <0x0 0xff9d0000 0x0 0x100>;
+                        clock-names = "bus_clk", "ref_clk";
+                        ranges;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        clocks = <&versal_clk 0x5b>,
+                         <&versal_clk 0x68>;
+                        power-domains = <&versal_firmware 0x18224018>;
+                        resets = <&versal_reset 0xc104036>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_usb";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_usb_0";
+                        phandle = <0x60>;
+
+                        dwc3_0: usb@fe200000 {
+                                compatible = "snps,dwc3";
+                                status = "okay";
+                                reg = <0x0 0xfe200000 0x0 0x10000>;
+                                interrupt-names = "host", "peripheral", "otg", "wakeup";
+                                interrupts = <0x0 0x16 0x4 0x0 0x16 0x4 0x0 0x1a 0x4 0x0 0x4a 0x4>;
+                                snps,dis_u2_susphy_quirk;
+                                snps,dis_u3_susphy_quirk;
+                                snps,quirk-frame-length-adjustment = <0x20>;
+                                clock-names = "ref";
+                                clocks = <&versal_clk 0x5b>;
+                                xlnx,rable = <0x0>;
+                                xlnx,is-cache-coherent = <0x0>;
+                                xlnx,ip-name = "psv_usb_xhci";
+                                xlnx,name = "versal_cips_0_pspmc_0_psv_usb_xhci_0";
+                                dr_mode = "host";
+                                maximum-speed = "high-speed";
+                                snps,usb3_lpm_capable;
+                                phandle = <0x4e>;
+                        };
+                };
+
+                cpm_pciea: pci@fca10000 {
+                        device_type = "pci";
+                        #address-cells = <0x3>;
+                        #interrupt-cells = <0x1>;
+                        #size-cells = <0x2>;
+                        compatible = "xlnx,versal-cpm-host-1.00";
+                        status = "okay";
+                        interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc_0 0x0>,
+                         <0x0 0x0 0x0 0x2 &pcie_intc_0 0x1>,
+                         <0x0 0x0 0x0 0x3 &pcie_intc_0 0x2>,
+                         <0x0 0x0 0x0 0x4 &pcie_intc_0 0x3>;
+                        interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+                        interrupt-names = "misc";
+                        interrupts = <0x0 0x48 0x4>;
+                        xlnx,csr-slcr = <0x6 0x0>;
+                        xlnx,num-of-bars = <0x2>;
+                        xlnx,port-type = <0x1>;
+                        interrupt-parent = <&imux>;
+                        bus-range = <0x0 0xff>;
+                        ranges = <0x2000000 0x0 0xe0010000 0x0 0xe0010000 0x0 0x10000000 0x43000000 0x80 0x0 0x80 0x0 0x0 0x80000000>;
+                        msi-map = <0x0 0x4 0x0 0x10000>;
+                        reg = <0x6 0x0 0x0 0x1000000 0x0 0xfca10000 0x0 0x1000>;
+                        reg-names = "cfg", "cpm_slcr";
+                        xlnx,rable = <0x0>;
+                        xlnx,cpm5-slcr-addr = <0xfcdd0000>;
+                        xlnx,ip-name = "psv_cpm";
+                        xlnx,cpm-slcr = <0xfca10000>;
+                        xlnx,cpm5-dma0-csr-addr = <0xfce20000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_cpm";
+                        phandle = <0x41>;
+
+                        pcie_intc_0: interrupt-controller {
+                                #address-cells = <0x0>;
+                                #interrupt-cells = <0x1>;
+                                interrupt-controller;
+                                phandle = <0x98>;
+                        };
+                };
+
+                cpm5_pcie: pcie@fcdd0000 {
+                        device_type = "pci";
+                        #address-cells = <0x3>;
+                        #interrupt-cells = <0x1>;
+                        #size-cells = <0x2>;
+                        compatible = "xlnx,versal-cpm5-host";
+                        status = "disabled";
+                        interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc_2 0x0>,
+                         <0x0 0x0 0x0 0x2 &pcie_intc_2 0x1>,
+                         <0x0 0x0 0x0 0x3 &pcie_intc_2 0x2>,
+                         <0x0 0x0 0x0 0x4 &pcie_intc_2 0x3>;
+                        interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+                        interrupt-names = "misc";
+                        interrupts = <0x0 0x48 0x4>;
+                        xlnx,csr-slcr = <0xfce20000>;
+                        xlnx,num-of-bars = <0x2>;
+                        xlnx,port-type = <0x1>;
+                        interrupt-parent = <&imux>;
+                        bus-range = <0x0 0xff>;
+                        ranges = <0x2000000 0x0 0xe0000000 0x0 0xe0000000 0x0 0x10000000 0x43000000 0x80 0x0 0x80 0x0 0x0 0x80000000>;
+                        msi-map = <0x0 0x4 0x0 0x10000>;
+                        reg = <0x6 0x0 0x0 0x1000000 0x0 0xfcdd0000 0x0 0x1000 0x0 0xfce20000 0x0 0x1000000>;
+                        reg-names = "cfg", "cpm_slcr", "cpm_csr";
+                        phandle = <0xc5>;
+
+                        pcie_intc_2: interrupt-controller {
+                                #address-cells = <0x0>;
+                                #interrupt-cells = <0x1>;
+                                interrupt-controller;
+                                phandle = <0x99>;
+                        };
+                };
+
+                watchdog: watchdog@fd4d0000 {
+                        compatible = "xlnx,versal-wwdt";
+                        status = "disabled";
+                        reg = <0x0 0xfd4d0000 0x0 0x10000>;
+                        interrupt-names = "wdt", "wwdt_reset_pending", "gwdt", "gwdt_reset_pending";
+                        interrupts = <0x0 0x64 0x1 0x0 0x6d 0x1 0x0 0x6c 0x1 0x0 0x6e 0x1>;
+                        interrupt-parent = <&imux>;
+                        timeout-sec = <0x1e>;
+                        clocks = <&versal_clk 0x4c>;
+                        power-domains = <&versal_firmware 0x18224029>;
+                        phandle = <0xc6>;
+                };
+
+                watchdog1: watchdog@ff120000 {
+                        compatible = "xlnx,versal-wwdt";
+                        status = "disabled";
+                        reg = <0x0 0xff120000 0x0 0x10000>;
+                        interrupt-parent = <&imux>;
+                        interrupt-names = "wdt", "wwdt_reset_pending", "gwdt", "gwdt_reset_pending";
+                        interrupts = <0x0 0x31 0x1 0x0 0x45 0x1 0x0 0x46 0x4 0x0 0x47 0x4>;
+                        timeout-sec = <0x1e>;
+                        clocks = <&versal_clk 0x52>;
+                        power-domains = <&versal_firmware 0x18224028>;
+                        phandle = <0xc7>;
+                };
+
+                xilsem_edac: edac@f2014050 {
+                        compatible = "xlnx,versal-xilsem-edac";
+                        status = "disabled";
+                        reg = <0x0 0xf2014050 0x0 0xc4>;
+                        phandle = <0xc8>;
+                };
+
+                dma0: pmcdma@f11c0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-csudma-1.0";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x83 0x4>;
+                        reg = <0x0 0xf11c0000 0x0 0x10000>;
+                        xlnx,dma-type = <0x1>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_dma";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_dma_0";
+                        phandle = <0x2c>;
+                };
+
+                dma1: pmcdma@f11d0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-csudma-1.0";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x84 0x4>;
+                        reg = <0x0 0xf11d0000 0x0 0x10000>;
+                        xlnx,dma-type = <0x2>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_dma";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_dma_1";
+                        phandle = <0x2d>;
+                };
+
+                iomodule0: iomodule@f0280000 {
+                        status = "okay";
+                        compatible = "xlnx,iomodule-3.1";
+                        reg = <0x0 0xf0280000 0x0 0x1000 0xffffffff 0xffffffff 0x0 0xe0000>;
+                        xlnx,intc-has-fast = <0x0>;
+                        xlnx,intc-base-vectors = <0xf0240000>;
+                        xlnx,intc-addr-width = <0x20>;
+                        xlnx,intc-level-edge = <0x7fff>;
+                        xlnx,clock-freq = <0x5f5e100>;
+                        xlnx,uart-baudrate = <0x1c200>;
+                        xlnx,pit-used = <0x1 0x1 0x1 0x1>;
+                        xlnx,pit-size = <0x20 0x20 0x20 0x20>;
+                        xlnx,pit-mask = <0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+                        xlnx,pit-prescaler = <0x9 0x0 0x9 0x0>;
+                        xlnx,pit-readable = <0x1 0x1 0x1 0x1>;
+                        xlnx,gpo-init = <0x0 0x0 0x0 0x0>;
+                        xlnx,options = <0x1>;
+                        xlnx,max-intr-size = <0x20>;
+                        xlnx,gpo4-size = <0x20>;
+                        xlnx,tmr = <0x0>;
+                        xlnx,pit1-readable = <0x1>;
+                        xlnx,mask = <0xfffff000>;
+                        xlnx,pit2-prescaler = <0x0>;
+                        xlnx,gpi3-interrupt = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,intc-positive = <0xffff>;
+                        xlnx,ip-name = "iomodule";
+                        xlnx,gpo1-size = <0x3>;
+                        xlnx,pit3-size = <0x20>;
+                        xlnx,fit3-interrupt = <0x0>;
+                        xlnx,fit1-no-clocks = <0x1848>;
+                        xlnx,gpi2-size = <0x20>;
+                        xlnx,pit2-readable = <0x1>;
+                        xlnx,intc-irq-connection = <0x0>;
+                        xlnx,uart-tx-interrupt = <0x1>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,pit2-interrupt = <0x1>;
+                        xlnx,gpo4-init = <0x0>;
+                        xlnx,pit3-readable = <0x1>;
+                        xlnx,pit3-prescaler = <0x9>;
+                        xlnx,gpi4-interrupt = <0x0>;
+                        xlnx,gpo1-init = <0x0>;
+                        xlnx,use-io-bus = <0x0>;
+                        xlnx,use-gpo1 = <0x1>;
+                        xlnx,fit4-interrupt = <0x0>;
+                        xlnx,gpo3-size = <0x20>;
+                        xlnx,use-gpo2 = <0x0>;
+                        xlnx,uart-data-bits = <0x8>;
+                        xlnx,gpio1-board-interface = "Custom";
+                        xlnx,use-gpo3 = <0x0>;
+                        xlnx,fit2-no-clocks = <0x1848>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,use-gpo4 = <0x0>;
+                        xlnx,gpi4-size = <0x20>;
+                        xlnx,gpio3-board-interface = "Custom";
+                        xlnx,uart-rx-interrupt = <0x1>;
+                        xlnx,uart-error-interrupt = <0x1>;
+                        xlnx,gpio4-board-interface = "Custom";
+                        xlnx,pit4-readable = <0x1>;
+                        xlnx,intc-use-irq-out = <0x0>;
+                        xlnx,use-board-flow;
+                        xlnx,pit2-size = <0x20>;
+                        xlnx,intc-intr-size = <0x10>;
+                        xlnx,intc-use-ext-intr = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_iomodule_0";
+                        xlnx,gpi1-size = <0x20>;
+                        xlnx,edk-special = "INTR_CTRL";
+                        xlnx,pit3-interrupt = <0x1>;
+                        xlnx,use-gpi1 = <0x0>;
+                        xlnx,gpi1-interrupt = <0x0>;
+                        xlnx,use-gpi2 = <0x0>;
+                        xlnx,use-gpi3 = <0x0>;
+                        xlnx,use-gpi4 = <0x0>;
+                        xlnx,fit1-interrupt = <0x0>;
+                        xlnx,pit4-prescaler = <0x0>;
+                        xlnx,gpo3-init = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,fit3-no-clocks = <0x1848>;
+                        xlnx,use-uart-rx = <0x1>;
+                        xlnx,instance = "iomodule_0";
+                        xlnx,uart-prog-baudrate = <0x1>;
+                        xlnx,use-pit1 = <0x1>;
+                        xlnx,gpo2-size = <0x20>;
+                        xlnx,use-pit2 = <0x1>;
+                        xlnx,pit4-size = <0x20>;
+                        xlnx,use-pit3 = <0x1>;
+                        xlnx,use-pit4 = <0x1>;
+                        xlnx,pit4-interrupt = <0x1>;
+                        xlnx,gpi3-size = <0x20>;
+                        xlnx,intc-async-intr = <0xffff>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,gpi2-interrupt = <0x0>;
+                        xlnx,pit1-prescaler = <0x9>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,use-fit1 = <0x0>;
+                        xlnx,pit1-size = <0x20>;
+                        xlnx,intc-num-sync-ff = <0x2>;
+                        xlnx,uart-board-interface = "rs232_uart";
+                        xlnx,use-fit2 = <0x0>;
+                        xlnx,fit2-interrupt = <0x0>;
+                        xlnx,use-fit3 = <0x0>;
+                        xlnx,use-fit4 = <0x0>;
+                        xlnx,uart-use-parity = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,fit4-no-clocks = <0x1848>;
+                        xlnx,uart-odd-parity = <0x0>;
+                        xlnx,freq = <0x5f5e100>;
+                        xlnx,use-uart-tx = <0x1>;
+                        xlnx,pit1-interrupt = <0x1>;
+                        xlnx,gpo2-init = <0x0>;
+                        xlnx,io-mask = <0xfffe0000>;
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x7c>;
+                };
+
+                ipi_pmc: mailbox@ff320000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1b 0x4>;
+                        reg = <0x0 0xff320000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x2>;
+                        xlnx,ipi-id = <0x1>;
+                        xlnx,ipi-buf-index = <0x1>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "PMC";
+                        xlnx,buffer-base = <0xff3f0200>;
+                        xlnx,buffer-index = <0x1>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3b>;
+                        xlnx,bit-position = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_pmc";
+                        phandle = <0x77>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f02a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0280>;
+                                phandle = <0xc9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f02e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f02c0>;
+                                phandle = <0xca>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0320>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0300>;
+                                phandle = <0xcb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0360>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0340>;
+                                phandle = <0xcc>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f03a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0380>;
+                                phandle = <0xcd>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f03e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f03c0>;
+                                phandle = <0xce>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xcf>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0260>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0240>;
+                                phandle = <0xd0>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xd1>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0220>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0200>;
+                                phandle = <0xd2>;
+                        };
+                };
+
+                ipi_pmc_nobuf: mailbox@ff390000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1c 0x4>;
+                        reg = <0x0 0xff390000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x100>;
+                        xlnx,ipi-id = <0x8>;
+                        xlnx,ipi-buf-index = <0xffff>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "PMC";
+                        xlnx,buffer-base = "NIL";
+                        xlnx,buffer-index = "NIL";
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3c>;
+                        xlnx,bit-position = <0x8>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf";
+                        phandle = <0x78>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                phandle = <0xd3>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                phandle = <0xd4>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                phandle = <0xd5>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                phandle = <0xd6>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                phandle = <0xd7>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                phandle = <0xd8>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xd9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                phandle = <0xda>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xdb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                phandle = <0xdc>;
+                        };
+                };
+
+                ipi_psm: mailbox@ff310000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1d 0x4>;
+                        reg = <0x0 0xff310000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x1>;
+                        xlnx,ipi-id = <0x0>;
+                        xlnx,ipi-buf-index = <0x0>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "PSM";
+                        xlnx,buffer-base = <0xff3f0000>;
+                        xlnx,buffer-index = <0x0>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3d>;
+                        xlnx,bit-position = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_psm";
+                        phandle = <0x7e>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f00a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0080>;
+                                phandle = <0xdd>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f00e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f00c0>;
+                                phandle = <0xde>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0120>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0100>;
+                                phandle = <0xdf>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0160>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0140>;
+                                phandle = <0xe0>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f01a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0180>;
+                                phandle = <0xe1>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f01e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f01c0>;
+                                phandle = <0xe2>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xe3>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0060>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0040>;
+                                phandle = <0xe4>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xe5>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_psm_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0020>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0000>;
+                                phandle = <0xe6>;
+                        };
+                };
+
+                ipi0: mailbox@ff330000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1e 0x4>;
+                        reg = <0x0 0xff330000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x4>;
+                        xlnx,ipi-id = <0x2>;
+                        xlnx,ipi-buf-index = <0x2>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0400>;
+                        xlnx,buffer-index = <0x2>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3e>;
+                        xlnx,bit-position = <0x2>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_0";
+                        phandle = <0x5>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f04a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0480>;
+                                phandle = <0xe7>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f04e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f04c0>;
+                                phandle = <0xe8>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0520>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0500>;
+                                phandle = <0xe9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0560>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0540>;
+                                phandle = <0xea>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f05a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0580>;
+                                phandle = <0xeb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f05e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f05c0>;
+                                phandle = <0xec>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xed>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0460>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0440>;
+                                phandle = <0xee>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xef>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_0_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0420>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0400>;
+                                phandle = <0xf0>;
+                        };
+                };
+
+                ipi1: mailbox@ff340000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x1f 0x4>;
+                        reg = <0x0 0xff340000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x8>;
+                        xlnx,ipi-id = <0x3>;
+                        xlnx,ipi-buf-index = <0x3>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0600>;
+                        xlnx,buffer-index = <0x3>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x3f>;
+                        xlnx,bit-position = <0x3>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_1";
+                        phandle = <0x6>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f06a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0680>;
+                                phandle = <0xf1>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f06e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f06c0>;
+                                phandle = <0xf2>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0720>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0700>;
+                                phandle = <0xf3>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0760>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0740>;
+                                phandle = <0xf4>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f07a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0780>;
+                                phandle = <0xf5>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f07e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f07c0>;
+                                phandle = <0xf6>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xf7>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0660>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0640>;
+                                phandle = <0xf8>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0xf9>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_1_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0620>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0600>;
+                                phandle = <0xfa>;
+                        };
+                };
+
+                ipi2: mailbox@ff350000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x20 0x4>;
+                        reg = <0x0 0xff350000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x10>;
+                        xlnx,ipi-id = <0x4>;
+                        xlnx,ipi-buf-index = <0x4>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0800>;
+                        xlnx,buffer-index = <0x4>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x40>;
+                        xlnx,bit-position = <0x4>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_2";
+                        phandle = <0x7>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f08a0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0880>;
+                                phandle = <0xfb>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f08e0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f08c0>;
+                                phandle = <0xfc>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0920>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0900>;
+                                phandle = <0xfd>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0960>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0940>;
+                                phandle = <0xfe>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f09a0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0980>;
+                                phandle = <0xff>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f09e0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f09c0>;
+                                phandle = <0x100>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x101>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0860>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0840>;
+                                phandle = <0x102>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x103>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_2_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0820>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0800>;
+                                phandle = <0x104>;
+                        };
+                };
+
+                ipi3: mailbox@ff360000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x21 0x4>;
+                        reg = <0x0 0xff360000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x20>;
+                        xlnx,ipi-id = <0x5>;
+                        xlnx,ipi-buf-index = <0x5>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0a00>;
+                        xlnx,buffer-index = <0x5>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x41>;
+                        xlnx,bit-position = <0x5>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_3";
+                        phandle = <0x8>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0aa0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0a80>;
+                                phandle = <0x105>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ae0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0ac0>;
+                                phandle = <0x106>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0b20>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0b00>;
+                                phandle = <0x107>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0b60>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0b40>;
+                                phandle = <0x108>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ba0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0b80>;
+                                phandle = <0x109>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0be0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0bc0>;
+                                phandle = <0x10a>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x10b>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0a60>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0a40>;
+                                phandle = <0x10c>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x10d>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_3_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0a20>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0a00>;
+                                phandle = <0x10e>;
+                        };
+                };
+
+                ipi4: mailbox@ff370000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x22 0x4>;
+                        reg = <0x0 0xff370000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x40>;
+                        xlnx,ipi-id = <0x6>;
+                        xlnx,ipi-buf-index = <0x6>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0c00>;
+                        xlnx,buffer-index = <0x6>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x42>;
+                        xlnx,bit-position = <0x6>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_4";
+                        phandle = <0x9>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ca0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0c80>;
+                                phandle = <0x10f>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ce0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0cc0>;
+                                phandle = <0x110>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0d20>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0d00>;
+                                phandle = <0x111>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0d60>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0d40>;
+                                phandle = <0x112>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0da0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0d80>;
+                                phandle = <0x113>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0de0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0dc0>;
+                                phandle = <0x114>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x115>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0c60>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0c40>;
+                                phandle = <0x116>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x117>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_4_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0c20>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0c00>;
+                                phandle = <0x118>;
+                        };
+                };
+
+                ipi5: mailbox@ff380000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x23 0x4>;
+                        reg = <0x0 0xff380000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x80>;
+                        xlnx,ipi-id = <0x7>;
+                        xlnx,ipi-buf-index = <0x7>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = <0xff3f0e00>;
+                        xlnx,buffer-index = <0x7>;
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x43>;
+                        xlnx,bit-position = <0x7>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_5";
+                        phandle = <0xa>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ea0>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0e80>;
+                                phandle = <0x119>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0ee0>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0ec0>;
+                                phandle = <0x11a>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0f20>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0f00>;
+                                phandle = <0x11b>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0f60>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0f40>;
+                                phandle = <0x11c>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0fa0>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0f80>;
+                                phandle = <0x11d>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0fe0>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0fc0>;
+                                phandle = <0x11e>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x11f>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0e60>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0e40>;
+                                phandle = <0x120>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x121>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_5_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-rsp-msg-buf = <0xff3f0e20>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                xlnx,ipi-req-msg-buf = <0xff3f0e00>;
+                                phandle = <0x122>;
+                        };
+                };
+
+                ipi6: mailbox@ff3a0000 {
+                        status = "okay";
+                        compatible = "xlnx,zynqmp-ipi-mailbox";
+                        interrupt-parent = <&imux>;
+                        interrupts = <0x0 0x24 0x4>;
+                        reg = <0x0 0xff3a0000 0x0 0x20>;
+                        xlnx,ipi-bitmask = <0x200>;
+                        xlnx,ipi-id = <0x9>;
+                        xlnx,ipi-buf-index = <0xffff>;
+                        #address-cells = <0x2>;
+                        #size-cells = <0x2>;
+                        ranges;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpu-name = "A72";
+                        xlnx,buffer-base = "NIL";
+                        xlnx,buffer-index = "NIL";
+                        xlnx,ip-name = "psv_ipi";
+                        xlnx,ipi-target-count = <0xa>;
+                        xlnx,int-id = <0x44>;
+                        xlnx,bit-position = <0x9>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_6";
+                        phandle = <0xb>;
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_0: child@0 {
+                                xlnx,ipi-bitmask = <0x4>;
+                                xlnx,ipi-id = <0x2>;
+                                xlnx,ipi-buf-index = <0x2>;
+                                phandle = <0x123>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_1: child@1 {
+                                xlnx,ipi-bitmask = <0x8>;
+                                xlnx,ipi-id = <0x3>;
+                                xlnx,ipi-buf-index = <0x3>;
+                                phandle = <0x124>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_2: child@2 {
+                                xlnx,ipi-bitmask = <0x10>;
+                                xlnx,ipi-id = <0x4>;
+                                xlnx,ipi-buf-index = <0x4>;
+                                phandle = <0x125>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_3: child@3 {
+                                xlnx,ipi-bitmask = <0x20>;
+                                xlnx,ipi-id = <0x5>;
+                                xlnx,ipi-buf-index = <0x5>;
+                                phandle = <0x126>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_4: child@4 {
+                                xlnx,ipi-bitmask = <0x40>;
+                                xlnx,ipi-id = <0x6>;
+                                xlnx,ipi-buf-index = <0x6>;
+                                phandle = <0x127>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_5: child@5 {
+                                xlnx,ipi-bitmask = <0x80>;
+                                xlnx,ipi-id = <0x7>;
+                                xlnx,ipi-buf-index = <0x7>;
+                                phandle = <0x128>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_6: child@6 {
+                                xlnx,ipi-bitmask = <0x200>;
+                                xlnx,ipi-id = <0x9>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x129>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_7: child@7 {
+                                xlnx,ipi-bitmask = <0x2>;
+                                xlnx,ipi-id = <0x1>;
+                                xlnx,ipi-buf-index = <0x1>;
+                                phandle = <0x12a>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_8: child@8 {
+                                xlnx,ipi-bitmask = <0x100>;
+                                xlnx,ipi-id = <0x8>;
+                                xlnx,ipi-buf-index = <0xffff>;
+                                phandle = <0x12b>;
+                        };
+
+                        versal_cips_0_pspmc_0_psv_ipi_6_9: child@9 {
+                                xlnx,ipi-bitmask = <0x1>;
+                                xlnx,ipi-id = <0x0>;
+                                xlnx,ipi-buf-index = <0x0>;
+                                phandle = <0x12c>;
+                        };
+                };
+
+                coresight: coresight@f0800000 {
+                        compatible = "xlnx,coresight-1.0";
+                        status = "okay";
+                        reg = <0x0 0xf0800000 0x0 0x10000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_coresight";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_0";
+                        phandle = <0xf>;
+                };
+
+                versal_cips_0_cpm_0_psv_cpm: versal_cips_0_cpm_0_psv_cpm@0 {
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-2 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-3 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-4 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-1 = <0x0>;
+                        xlnx,cpm-req-agents-0-enable = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-2 = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-3 = <0x0>;
+                        xlnx,ip-name = "psv_cpm";
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-7 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-4 = <0x0>;
+                        reg = <0x0 0xfc000000 0x0 0x1000000>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-baseaddress-7 = <0x0>;
+                        xlnx,axibar-0 = <0x0>;
+                        xlnx,axibar-1 = <0x0>;
+                        xlnx,cpm-axi-slv-xdma0-base-addrr-h = <0x6>;
+                        xlnx,cpm-ccix-port-aggregation-enable = <0x0>;
+                        xlnx,cpm-pcie1-port-type = <0x0>;
+                        xlnx,cpm-pcie1-edr-link-speed = <0x0>;
+                        xlnx,cpm-pcie1-axibar-num = <0x1>;
+                        compatible = "xlnx,psv-cpm-1.0";
+                        xlnx,cpm-axi-slv-xdma0-base-addrr-l = <0x11000000>;
+                        xlnx,axibar-num = <0x1>;
+                        xlnx,nocpspcie0-region0 = <0x6 0x0>;
+                        xlnx,nocpspcie1-region0 = <0x6 0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-highaddr-0 = <0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-highaddr-1 = <0x0>;
+                        xlnx,cpm-pcie0-edr-link-speed = <0x0>;
+                        xlnx,cpm-axi-slv-bridge0-base-addrr-h = <0x6>;
+                        xlnx,cpm-pcie0-controller-enable = <0x1>;
+                        xlnx,axibar-highaddr-0 = <0xfff>;
+                        xlnx,axibar-highaddr-1 = <0x0>;
+                        xlnx,cpm-axi-slv-bridge0-base-addrr-l = <0x0>;
+                        status = "okay";
+                        xlnx,cpm-ccix-partial-cacheline-support = <0x0>;
+                        xlnx,name = "versal_cips_0_cpm_0_psv_cpm";
+                        xlnx,cpm-pcie1-pf0-cfg-dev-id = "B03F";
+                        xlnx,cpm-ccix-select-agent = <0x0>;
+                        xlnx,is-hierarchy;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-0 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-1 = <0x4>;
+                        xlnx,cpm-revision-number = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-2 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-3 = <0x4>;
+                        xlnx,cpm-pcie1-controller-enable = <0x0>;
+                        xlnx,cpm-pcie0-pf0-cfg-dev-id = "B03C";
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-4 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-5 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-6 = <0x4>;
+                        xlnx,cpm-num-ccix-credit-links = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-attrib-7 = <0x4>;
+                        xlnx,cpm-num-home-or-slave-agents = <0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-baseaddr-0 = <0x0>;
+                        xlnx,cpm-pcie1-pf0-axibar2pcie-baseaddr-1 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-1 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-0 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-2 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-1 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-3 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-1 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-2 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-4 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-3 = <0x4>;
+                        xlnx,cpm-axi-slv-multq0-base-addrr-h = <0x6>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-2 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-4 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-3 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-5 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-4 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-type-7 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-6 = <0x4>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-5 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-size-7 = <0x4>;
+                        xlnx,cpm-axi-slv-multq0-base-addrr-l = <0x10000000>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-6 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-region-7 = <0x0>;
+                        xlnx,cpm-req-agents-1-enable = <0x0>;
+                        xlnx,cpm-pcie0-port-type = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-0 = <0x0>;
+                        xlnx,cpm-ccix-rsvrd-memory-agent-type-1 = <0x0>;
+                        phandle = <0x12d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_apu_0: versal_cips_0_pspmc_0_psv_apu_0@fd5c0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-apu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_apu";
+                        reg = <0x0 0xfd5c0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_apu_0";
+                        phandle = <0x47>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_cti: versal_cips_0_pspmc_0_psv_coresight_a720_cti@f0d10000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-cti-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_cti";
+                        reg = <0x0 0xf0d10000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_cti";
+                        phandle = <0x18>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_dbg: versal_cips_0_pspmc_0_psv_coresight_a720_dbg@f0d00000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-dbg-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_dbg";
+                        reg = <0x0 0xf0d00000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_dbg";
+                        phandle = <0x17>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_etm: versal_cips_0_pspmc_0_psv_coresight_a720_etm@f0d30000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-etm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_etm";
+                        reg = <0x0 0xf0d30000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_etm";
+                        phandle = <0x1a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a720_pmu: versal_cips_0_pspmc_0_psv_coresight_a720_pmu@f0d20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a720-pmu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a720_pmu";
+                        reg = <0x0 0xf0d20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a720_pmu";
+                        phandle = <0x19>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_cti: versal_cips_0_pspmc_0_psv_coresight_a721_cti@f0d50000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-cti-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_cti";
+                        reg = <0x0 0xf0d50000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_cti";
+                        phandle = <0x1c>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_dbg: versal_cips_0_pspmc_0_psv_coresight_a721_dbg@f0d40000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-dbg-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_dbg";
+                        reg = <0x0 0xf0d40000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_dbg";
+                        phandle = <0x1b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_etm: versal_cips_0_pspmc_0_psv_coresight_a721_etm@f0d70000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-etm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_etm";
+                        reg = <0x0 0xf0d70000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_etm";
+                        phandle = <0x1e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_a721_pmu: versal_cips_0_pspmc_0_psv_coresight_a721_pmu@f0d60000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-a721-pmu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_a721_pmu";
+                        reg = <0x0 0xf0d60000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_a721_pmu";
+                        phandle = <0x1d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_cti: versal_cips_0_pspmc_0_psv_coresight_apu_cti@f0ca0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-cti-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_cti";
+                        reg = <0x0 0xf0ca0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_cti";
+                        phandle = <0x16>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_ela: versal_cips_0_pspmc_0_psv_coresight_apu_ela@f0c60000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-ela-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_ela";
+                        reg = <0x0 0xf0c60000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_ela";
+                        phandle = <0x15>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_etf: versal_cips_0_pspmc_0_psv_coresight_apu_etf@f0c30000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-etf-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_etf";
+                        reg = <0x0 0xf0c30000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_etf";
+                        phandle = <0x14>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_apu_fun: versal_cips_0_pspmc_0_psv_coresight_apu_fun@f0c20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-apu-fun-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_apu_fun";
+                        reg = <0x0 0xf0c20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_apu_fun";
+                        phandle = <0x13>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_atm: versal_cips_0_pspmc_0_psv_coresight_cpm_atm@f0f80000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-atm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_atm";
+                        reg = <0x0 0xf0f80000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_atm";
+                        phandle = <0x25>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a: versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a@f0fa0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-cti2a-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_cti2a";
+                        reg = <0x0 0xf0fa0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a";
+                        phandle = <0x26>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d: versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d@f0fd0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-cti2d-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_cti2d";
+                        reg = <0x0 0xf0fd0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d";
+                        phandle = <0x27>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a@f0f40000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2a-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2a";
+                        reg = <0x0 0xf0f40000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a";
+                        phandle = <0x21>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b@f0f50000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2b-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2b";
+                        reg = <0x0 0xf0f50000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b";
+                        phandle = <0x22>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c@f0f60000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2c-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2c";
+                        reg = <0x0 0xf0f60000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c";
+                        phandle = <0x23>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d: versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d@f0f70000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-ela2d-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_ela2d";
+                        reg = <0x0 0xf0f70000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d";
+                        phandle = <0x24>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_fun: versal_cips_0_pspmc_0_psv_coresight_cpm_fun@f0f20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-fun-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_fun";
+                        reg = <0x0 0xf0f20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_fun";
+                        phandle = <0x20>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_cpm_rom: versal_cips_0_pspmc_0_psv_coresight_cpm_rom@f0f00000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-cpm-rom-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_cpm_rom";
+                        reg = <0x0 0xf0f00000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_cpm_rom";
+                        phandle = <0x1f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_fpd_atm: versal_cips_0_pspmc_0_psv_coresight_fpd_atm@f0b80000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-fpd-atm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_fpd_atm";
+                        reg = <0x0 0xf0b80000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_fpd_atm";
+                        phandle = <0x12>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_fpd_stm: versal_cips_0_pspmc_0_psv_coresight_fpd_stm@f0b70000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-fpd-stm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_fpd_stm";
+                        reg = <0x0 0xf0b70000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_fpd_stm";
+                        phandle = <0x11>;
+                };
+
+                versal_cips_0_pspmc_0_psv_coresight_lpd_atm: versal_cips_0_pspmc_0_psv_coresight_lpd_atm@f0980000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-coresight-lpd-atm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_coresight_lpd_atm";
+                        reg = <0x0 0xf0980000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_coresight_lpd_atm";
+                        phandle = <0x10>;
+                };
+
+                versal_cips_0_pspmc_0_psv_crf_0: versal_cips_0_pspmc_0_psv_crf_0@fd1a0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-crf-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_crf";
+                        reg = <0x0 0xfd1a0000 0x0 0x140000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_crf_0";
+                        phandle = <0x43>;
+                };
+
+                versal_cips_0_pspmc_0_psv_crl_0: versal_cips_0_pspmc_0_psv_crl_0@ff5e0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-crl-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_crl";
+                        reg = <0x0 0xff5e0000 0x0 0x300000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_crl_0";
+                        phandle = <0x5a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_crp_0: versal_cips_0_pspmc_0_psv_crp_0@f1260000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-crp-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_crp";
+                        reg = <0x0 0xf1260000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_crp_0";
+                        phandle = <0x36>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_0: versal_cips_0_pspmc_0_psv_fpd_afi_0@fd360000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi";
+                        reg = <0x0 0xfd360000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_0";
+                        phandle = <0x44>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_2: versal_cips_0_pspmc_0_psv_fpd_afi_2@fd380000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi";
+                        reg = <0x0 0xfd380000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_2";
+                        phandle = <0x45>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_0: versal_cips_0_pspmc_0_psv_fpd_afi_mem_0@a4000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-mem-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi_mem";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xa4000000 0x0 0xc000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_mem_0";
+                        phandle = <0x12e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_2: versal_cips_0_pspmc_0_psv_fpd_afi_mem_2@b0000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-afi-mem-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_afi_mem";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xb0000000 0x0 0x10000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_afi_mem_2";
+                        phandle = <0x12f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_cci_0: versal_cips_0_pspmc_0_psv_fpd_cci_0@fd5e0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-cci-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_cci";
+                        reg = <0x0 0xfd5e0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_cci_0";
+                        phandle = <0x48>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_gpv_0: versal_cips_0_pspmc_0_psv_fpd_gpv_0@fd700000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-gpv-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_gpv";
+                        reg = <0x0 0xfd700000 0x0 0x100000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_gpv_0";
+                        phandle = <0x4c>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_slcr_0: versal_cips_0_pspmc_0_psv_fpd_slcr_0@fd610000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_slcr";
+                        reg = <0x0 0xfd610000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_slcr_0";
+                        phandle = <0x4a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0: versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0@fd690000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-slcr-secure-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_slcr_secure";
+                        reg = <0x0 0xfd690000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0";
+                        phandle = <0x4b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_fpd_smmu_0: versal_cips_0_pspmc_0_psv_fpd_smmu_0@fd5f0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-fpd-smmu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_fpd_smmu";
+                        reg = <0x0 0xfd5f0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_smmu_0";
+                        phandle = <0x49>;
+                };
+
+                versal_cips_0_pspmc_0_psv_ipi_buffer: versal_cips_0_pspmc_0_psv_ipi_buffer@ff3f0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-ipi-buffer-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_ipi_buffer";
+                        reg = <0x0 0xff3f0000 0x0 0x1000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ipi_buffer";
+                        phandle = <0x130>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_afi_0: versal_cips_0_pspmc_0_psv_lpd_afi_0@ff9b0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-afi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_afi";
+                        reg = <0x0 0xff9b0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_afi_0";
+                        phandle = <0x5f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_afi_mem_0: versal_cips_0_pspmc_0_psv_lpd_afi_mem_0@80000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-afi-mem-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_afi_mem";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0x80000000 0x0 0x20000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_afi_mem_0";
+                        phandle = <0x131>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0: versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0@ff0a0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-iou-secure-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_iou_secure_slcr";
+                        reg = <0x0 0xff0a0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0";
+                        phandle = <0x52>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0: versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0@ff080000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-iou-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_iou_slcr";
+                        reg = <0x0 0xff080000 0x0 0x20000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0";
+                        phandle = <0x51>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_slcr_0: versal_cips_0_pspmc_0_psv_lpd_slcr_0@ff410000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-slcr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_slcr";
+                        reg = <0x0 0xff410000 0x0 0x100000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_slcr_0";
+                        phandle = <0x58>;
+                };
+
+                versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0: versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0@ff510000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-lpd-slcr-secure-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_lpd_slcr_secure";
+                        reg = <0x0 0xff510000 0x0 0x40000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0";
+                        phandle = <0x59>;
+                };
+
+                versal_cips_0_pspmc_0_psv_noc_pcie_0: versal_cips_0_pspmc_0_psv_noc_pcie_0@e0000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-noc-pcie-0-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_noc_pcie_0";
+                        reg = <0x0 0xe0000000 0x0 0x10000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_noc_pcie_0";
+                        phandle = <0xd>;
+                };
+
+                versal_cips_0_pspmc_0_psv_noc_pcie_1: versal_cips_0_pspmc_0_psv_noc_pcie_1@600000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-noc-pcie-1-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_noc_pcie_1";
+                        reg = <0x6 0x0 0x2 0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_noc_pcie_1";
+                        phandle = <0x6d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_noc_pcie_2: versal_cips_0_pspmc_0_psv_noc_pcie_2@8000000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-noc-pcie-2-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_noc_pcie_2";
+                        reg = <0x80 0x0 0x40 0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_noc_pcie_2";
+                        phandle = <0x6e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_ocm_ctrl: versal_cips_0_pspmc_0_psv_ocm_ctrl@ff960000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-ocm-1.0";
+                        status = "okay";
+                        power-domains = <&versal_firmware 0x18314007>;
+                        xlnx,ip-name = "psv_ocm";
+                        reg = <0x0 0xff960000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ocm_ctrl";
+                        phandle = <0x5b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_aes: versal_cips_0_pspmc_0_psv_pmc_aes@f11e0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-aes-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_aes";
+                        reg = <0x0 0xf11e0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_aes";
+                        phandle = <0x2e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl: versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl@f11f0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-bbram-ctrl-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_bbram_ctrl";
+                        reg = <0x0 0xf11f0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl";
+                        phandle = <0x2f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0: versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0@f12d0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-cfi-cframe-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_cfi_cframe";
+                        reg = <0x0 0xf12d0000 0x0 0x1000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0";
+                        phandle = <0x3a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0: versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0@f12b0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-cfu-apb-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_cfu_apb";
+                        reg = <0x0 0xf12b0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0";
+                        phandle = <0x39>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_efuse_cache: versal_cips_0_pspmc_0_psv_pmc_efuse_cache@f1250000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-efuse-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_efuse_cache";
+                        reg = <0x0 0xf1250000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_efuse_cache";
+                        phandle = <0x35>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl: versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl@f1240000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-efuse-ctrl-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_efuse_ctrl";
+                        reg = <0x0 0xf1240000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl";
+                        phandle = <0x34>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_global_0: versal_cips_0_pspmc_0_psv_pmc_global_0@f1110000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-global-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_global";
+                        reg = <0x0 0xf1110000 0x0 0x50000>;
+                        xlnx,npi-scan = <0x0>;
+                        xlnx,event-log = <0x0>;
+                        xlnx,cram-scan = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_global_0";
+                        phandle = <0x2b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0: versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0@f0310000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-ppu1-mdm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_ppu1_mdm";
+                        reg = <0x0 0xf0310000 0x0 0x8000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0";
+                        phandle = <0xe>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram: versal_cips_0_pspmc_0_psv_pmc_ram@f2000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-ram-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_ram";
+                        reg = <0x0 0xf2000000 0x0 0x20000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram";
+                        phandle = <0x132>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr: versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr@f0240000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,ram-data-cntlr-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xffffffff 0xffffe000>;
+                        xlnx,mask1 = <0xffffffff 0xffffe000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "ram_data_cntlr";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xf0240000 0x0 0x20000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr";
+                        phandle = <0x7b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr: versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr@f0200000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,ram-instr-cntlr-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xfffe0000>;
+                        xlnx,mask1 = <0xfffe0000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "ram_instr_cntlr";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xf0200000 0x0 0x40000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr";
+                        phandle = <0x7a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_ram_npi: versal_cips_0_pspmc_0_psv_pmc_ram_npi@f6000000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-ram-npi-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_ram_npi";
+                        reg = <0x0 0xf6000000 0x0 0x2000000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_ram_npi";
+                        phandle = <0x3f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_rsa: versal_cips_0_pspmc_0_psv_pmc_rsa@f1200000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-rsa-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_rsa";
+                        reg = <0x0 0xf1200000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_rsa";
+                        phandle = <0x30>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_sha: versal_cips_0_pspmc_0_psv_pmc_sha@f1210000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-pmc-sha-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_sha";
+                        reg = <0x0 0xf1210000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_sha";
+                        phandle = <0x31>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot: versal_cips_0_pspmc_0_psv_pmc_slave_boot@f1220000 {
+                        xlnx,rable = <0x0>;
+                        xlnx,device-id = <0x0>;
+                        compatible = "xlnx,psv-pmc-slave-boot-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_slave_boot";
+                        reg = <0x0 0xf1220000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_slave_boot";
+                        phandle = <0x32>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream: versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream@f2100000 {
+                        xlnx,rable = <0x0>;
+                        xlnx,device-id = <0x0>;
+                        compatible = "xlnx,psv-pmc-slave-boot-stream-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_slave_boot_stream";
+                        reg = <0x0 0xf2100000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream";
+                        phandle = <0x3e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0: versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0@f0083000 {
+                        compatible = "xlnx,tmr-inject-1.0";
+                        xlnx,cpu-id = <0x1>;
+                        xlnx,edk-special = "tmr_inject";
+                        xlnx,mask = <0x84000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "tmr_inject";
+                        reg = <0x0 0xf0083000 0x0 0x1000>;
+                        xlnx,magic = <0x27>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        status = "okay";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x79>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0: versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0@f0283000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,use-debug-disable = <0x0>;
+                        xlnx,sem-interface-type = <0x1>;
+                        compatible = "xlnx,tmr-manager-1.0";
+                        xlnx,magic1 = <0x0>;
+                        xlnx,tmr = <0x1>;
+                        xlnx,magic2 = <0x0>;
+                        xlnx,brk-delay-rst-value = <0x0>;
+                        xlnx,mask = <0x83000>;
+                        xlnx,sem-heartbeat-watchdog-width = <0xa>;
+                        xlnx,rable = <0x0>;
+                        xlnx,watchdog-width = <0x1e>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,ue-width = <0x3>;
+                        xlnx,ip-name = "tmr_manager";
+                        xlnx,async-ff = <0x2>;
+                        xlnx,ue-is-fatal = <0x0>;
+                        xlnx,sem-heartbeat-watchdog = <0x0>;
+                        reg = <0x0 0xf0283000 0x0 0x1000>;
+                        xlnx,brk-delay-width = <0x0>;
+                        xlnx,watchdog = <0x0>;
+                        xlnx,sem-interface = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mask-rst-value = <0xffffffff 0xffffffff>;
+                        xlnx,comparators-mask = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,test-comparator = <0x0>;
+                        xlnx,strict-miscompare = <0x0>;
+                        status = "okay";
+                        xlnx,no-of-comparators = <0x1>;
+                        xlnx,sem-async = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x7d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_pmc_trng: versal_cips_0_pspmc_0_psv_pmc_trng@f1230000 {
+                        xlnx,rable = <0x0>;
+                        xlnx,device-id = <0x0>;
+                        compatible = "xlnx,psv-pmc-trng-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_pmc_trng";
+                        reg = <0x0 0xf1230000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_trng";
+                        phandle = <0x33>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_global_reg: versal_cips_0_pspmc_0_psv_psm_global_reg@ffc90000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-psm-global-reg-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_psm_global_reg";
+                        reg = <0x0 0xffc90000 0x0 0xf000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_global_reg";
+                        phandle = <0x69>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_iomodule_0: versal_cips_0_pspmc_0_psv_psm_iomodule_0@ffc80000 {
+                        xlnx,gpo4-size = <0x20>;
+                        xlnx,tmr = <0x0>;
+                        xlnx,pit1-readable = <0x1>;
+                        xlnx,mask = <0xffff8000>;
+                        xlnx,pit-size = <0x20 0x20 0x20 0x20>;
+                        xlnx,pit2-prescaler = <0x0>;
+                        xlnx,gpi3-interrupt = <0x0>;
+                        xlnx,intc-level-edge = <0x7fff>;
+                        xlnx,rable = <0x0>;
+                        xlnx,intc-positive = <0xffff>;
+                        xlnx,ip-name = "iomodule";
+                        xlnx,gpo1-size = <0x3>;
+                        xlnx,max-intr-size = <0x20>;
+                        xlnx,pit3-size = <0x20>;
+                        xlnx,fit3-interrupt = <0x0>;
+                        reg = <0x0 0xffc80000 0x0 0x8000>;
+                        xlnx,fit1-no-clocks = <0x1848>;
+                        xlnx,gpi2-size = <0x20>;
+                        xlnx,pit2-readable = <0x1>;
+                        xlnx,intc-irq-connection = <0x0>;
+                        xlnx,uart-tx-interrupt = <0x1>;
+                        xlnx,use-config-reset = <0x0>;
+                        xlnx,pit2-interrupt = <0x1>;
+                        xlnx,intc-base-vectors = <0xffc00000>;
+                        compatible = "xlnx,iomodule-1.0", "xlnx,iomodule-3.1";
+                        xlnx,gpo4-init = <0x0>;
+                        xlnx,pit3-readable = <0x1>;
+                        xlnx,pit3-prescaler = <0x9>;
+                        xlnx,gpi4-interrupt = <0x0>;
+                        xlnx,gpo1-init = <0x0>;
+                        xlnx,use-io-bus = <0x0>;
+                        xlnx,use-gpo1 = <0x1>;
+                        xlnx,uart-baudrate = <0x1c200>;
+                        xlnx,fit4-interrupt = <0x0>;
+                        xlnx,gpo3-size = <0x20>;
+                        xlnx,use-gpo2 = <0x0>;
+                        xlnx,uart-data-bits = <0x8>;
+                        xlnx,pit-prescaler = <0x9 0x0 0x9 0x0>;
+                        xlnx,gpio1-board-interface = "Custom";
+                        xlnx,use-gpo3 = <0x0>;
+                        xlnx,fit2-no-clocks = <0x1848>;
+                        xlnx,options = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,use-gpo4 = <0x0>;
+                        xlnx,gpi4-size = <0x20>;
+                        xlnx,gpio3-board-interface = "Custom";
+                        xlnx,uart-rx-interrupt = <0x1>;
+                        xlnx,uart-error-interrupt = <0x1>;
+                        xlnx,gpio4-board-interface = "Custom";
+                        xlnx,pit4-readable = <0x1>;
+                        status = "okay";
+                        xlnx,intc-use-irq-out = <0x0>;
+                        xlnx,clock-freq = <0x5f5e100>;
+                        xlnx,gpo-init = <0x0 0x0 0x0 0x0>;
+                        xlnx,use-board-flow;
+                        xlnx,pit2-size = <0x20>;
+                        xlnx,intc-intr-size = <0x10>;
+                        xlnx,intc-use-ext-intr = <0x1>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_iomodule_0";
+                        xlnx,gpi1-size = <0x20>;
+                        xlnx,edk-special = "INTR_CTRL";
+                        xlnx,pit3-interrupt = <0x1>;
+                        xlnx,intc-has-fast = <0x0>;
+                        xlnx,pit-used = <0x1 0x1 0x1 0x1>;
+                        xlnx,use-gpi1 = <0x0>;
+                        xlnx,gpi1-interrupt = <0x0>;
+                        xlnx,use-gpi2 = <0x0>;
+                        xlnx,use-gpi3 = <0x0>;
+                        xlnx,use-gpi4 = <0x0>;
+                        xlnx,fit1-interrupt = <0x0>;
+                        xlnx,pit4-prescaler = <0x0>;
+                        xlnx,gpo3-init = <0x0>;
+                        xlnx,intc-addr-width = <0x20>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,fit3-no-clocks = <0x1848>;
+                        xlnx,use-uart-rx = <0x1>;
+                        xlnx,instance = "iomodule_0";
+                        xlnx,pit-mask = <0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+                        xlnx,uart-prog-baudrate = <0x1>;
+                        xlnx,use-pit1 = <0x1>;
+                        xlnx,gpo2-size = <0x20>;
+                        xlnx,use-pit2 = <0x1>;
+                        xlnx,pit4-size = <0x20>;
+                        xlnx,pit-readable = <0x1 0x1 0x1 0x1>;
+                        xlnx,use-pit3 = <0x1>;
+                        xlnx,use-pit4 = <0x1>;
+                        xlnx,pit4-interrupt = <0x1>;
+                        xlnx,gpi3-size = <0x20>;
+                        xlnx,intc-async-intr = <0xffff>;
+                        xlnx,pit1-prescaler = <0x9>;
+                        xlnx,avoid-primitives = <0x0>;
+                        xlnx,gpi2-interrupt = <0x0>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,use-fit1 = <0x0>;
+                        xlnx,pit1-size = <0x20>;
+                        xlnx,intc-num-sync-ff = <0x2>;
+                        xlnx,uart-board-interface = "rs232_uart";
+                        xlnx,use-fit2 = <0x0>;
+                        xlnx,fit2-interrupt = <0x0>;
+                        xlnx,use-fit3 = <0x0>;
+                        xlnx,use-fit4 = <0x0>;
+                        xlnx,uart-use-parity = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,fit4-no-clocks = <0x1848>;
+                        xlnx,uart-odd-parity = <0x0>;
+                        xlnx,freq = <0x5f5e100>;
+                        xlnx,use-uart-tx = <0x1>;
+                        xlnx,pit1-interrupt = <0x1>;
+                        xlnx,gpo2-init = <0x0>;
+                        xlnx,io-mask = <0xfffe0000>;
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x81>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr: versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr@ffc20000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,PSM-PPU-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xffffffff 0xffffe000>;
+                        xlnx,mask1 = <0xffffffff 0xffffe000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "PSM_PPU";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xffc20000 0x0 0x20000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr";
+                        phandle = <0x80>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr: versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr@ffc00000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,write-access = <0x2>;
+                        compatible = "xlnx,ram-instr-cntlr-1.0";
+                        xlnx,ecc-onoff-register = <0x1>;
+                        xlnx,ecc-onoff-reset-value = <0x1>;
+                        xlnx,s-axi-ctrl-protocol = "AXI4LITE";
+                        xlnx,mask = <0xffffffff 0xfffe0000>;
+                        xlnx,mask1 = <0xffffffff 0xfffe0000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,s-axi-ctrl-aclk-freq-hz = <0x5f5e100>;
+                        xlnx,mask2 = <0x800000>;
+                        xlnx,fault-inject = <0x1>;
+                        xlnx,mask3 = <0x800000>;
+                        xlnx,ip-name = "ram_instr_cntlr";
+                        xlnx,num-lmb = <0x2>;
+                        reg = <0x0 0xffc00000 0x0 0x20000>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,ecc-status-registers = <0x1>;
+                        xlnx,ce-counter-width = <0x10>;
+                        xlnx,ecc = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,interconnect = <0x2>;
+                        xlnx,ce-failing-registers = <0x1>;
+                        xlnx,ue-failing-registers = <0x1>;
+                        status = "okay";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,bram-awidth = <0x20>;
+                        xlnx,lmb-awidth = <0x20>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr";
+                        phandle = <0x7f>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_tmr_inject_0: versal_cips_0_pspmc_0_psv_psm_tmr_inject_0@ffcd0000 {
+                        compatible = "xlnx,tmr-inject-1.0";
+                        xlnx,cpu-id = <0x1>;
+                        xlnx,edk-special = "tmr_inject";
+                        xlnx,mask = <0x50000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "tmr_inject";
+                        reg = <0x0 0xffcd0000 0x0 0x10000>;
+                        xlnx,magic = <0x27>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,edk-iptype = "PROCESSOR";
+                        status = "okay";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_tmr_inject_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x83>;
+                };
+
+                versal_cips_0_pspmc_0_psv_psm_tmr_manager_0: versal_cips_0_pspmc_0_psv_psm_tmr_manager_0@ffcc0000 {
+                        xlnx,edk-special = "BRAM_CTRL";
+                        xlnx,use-debug-disable = <0x0>;
+                        xlnx,sem-interface-type = <0x1>;
+                        compatible = "xlnx,tmr-manager-1.0";
+                        xlnx,magic1 = <0x0>;
+                        xlnx,tmr = <0x1>;
+                        xlnx,magic2 = <0x0>;
+                        xlnx,brk-delay-rst-value = <0x0>;
+                        xlnx,mask = <0x50000>;
+                        xlnx,sem-heartbeat-watchdog-width = <0xa>;
+                        xlnx,rable = <0x0>;
+                        xlnx,watchdog-width = <0x1e>;
+                        xlnx,use-tmr-disable = <0x0>;
+                        xlnx,ue-width = <0x3>;
+                        xlnx,ip-name = "tmr_manager";
+                        xlnx,async-ff = <0x2>;
+                        xlnx,ue-is-fatal = <0x0>;
+                        xlnx,sem-heartbeat-watchdog = <0x0>;
+                        reg = <0x0 0xffcc0000 0x0 0x10000>;
+                        xlnx,brk-delay-width = <0x0>;
+                        xlnx,watchdog = <0x0>;
+                        xlnx,sem-interface = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mask-rst-value = <0xffffffff 0xffffffff>;
+                        xlnx,comparators-mask = <0x0>;
+                        xlnx,lmb-dwidth = <0x20>;
+                        xlnx,test-comparator = <0x0>;
+                        xlnx,strict-miscompare = <0x0>;
+                        status = "okay";
+                        xlnx,no-of-comparators = <0x1>;
+                        xlnx,sem-async = <0x0>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_psm_tmr_manager_0";
+                        xlnx,lmb-awidth = <0x20>;
+                        phandle = <0x82>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_atcm: versal_cips_0_pspmc_0_psv_r5_0_atcm@0 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x0 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_atcm";
+                        phandle = <0x85>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep: versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep@ffe10000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-atcm-lockstep-1.0", "mmio-sram";
+                        status = "okay";
+                        power-domains = <&versal_firmware 0x1831800b>;
+                        xlnx,ip-name = "psv_r5_0_atcm_lockstep";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xffe10000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep";
+                        phandle = <0x133>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_btcm: versal_cips_0_pspmc_0_psv_r5_0_btcm@20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_btcm";
+                        phandle = <0x87>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep: versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep@ffe30000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-btcm-lockstep-1.0", "mmio-sram";
+                        status = "okay";
+                        power-domains = <&versal_firmware 0x1831800c>;
+                        xlnx,ip-name = "psv_r5_0_btcm_lockstep";
+                        xlnx,is-hierarchy;
+                        reg = <0x0 0xffe30000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep";
+                        phandle = <0x134>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_data_cache: versal_cips_0_pspmc_0_psv_r5_0_data_cache@ffe50000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-data-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_0_data_cache";
+                        reg = <0x0 0xffe50000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_data_cache";
+                        phandle = <0x8a>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_0_instruction_cache: versal_cips_0_pspmc_0_psv_r5_0_instruction_cache@ffe40000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-0-instruction-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_0_instruction_cache";
+                        reg = <0x0 0xffe40000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_instruction_cache";
+                        phandle = <0x89>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_atcm: versal_cips_0_pspmc_0_psv_r5_1_atcm@0 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x0 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_atcm";
+                        phandle = <0x8d>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_btcm: versal_cips_0_pspmc_0_psv_r5_1_btcm@20000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x20000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_btcm";
+                        phandle = <0x8e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_data_cache: versal_cips_0_pspmc_0_psv_r5_1_data_cache@ffed0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-1-data-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_1_data_cache";
+                        reg = <0x0 0xffed0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_data_cache";
+                        phandle = <0x8c>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_1_instruction_cache: versal_cips_0_pspmc_0_psv_r5_1_instruction_cache@ffec0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-1-instruction-cache-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_1_instruction_cache";
+                        reg = <0x0 0xffec0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_instruction_cache";
+                        phandle = <0x8b>;
+                };
+
+                versal_cips_0_pspmc_0_psv_r5_tcm_ram_0: versal_cips_0_pspmc_0_psv_r5_tcm_ram_0@0 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-r5-tcm-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_r5_tcm";
+                        reg = <0x0 0x0 0x0 0x40000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_r5_tcm_ram_0";
+                        phandle = <0x86>;
+                };
+
+                versal_cips_0_pspmc_0_psv_rpu_0: versal_cips_0_pspmc_0_psv_rpu_0@ff9a0000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-rpu-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_rpu";
+                        reg = <0x0 0xff9a0000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_rpu_0";
+                        phandle = <0x5e>;
+                };
+
+                versal_cips_0_pspmc_0_psv_scntr_0: versal_cips_0_pspmc_0_psv_scntr_0@ff130000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-scntr-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_scntr";
+                        reg = <0x0 0xff130000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_scntr_0";
+                        phandle = <0x56>;
+                };
+
+                versal_cips_0_pspmc_0_psv_scntrs_0: versal_cips_0_pspmc_0_psv_scntrs_0@ff140000 {
+                        xlnx,rable = <0x0>;
+                        compatible = "xlnx,psv-scntrs-1.0";
+                        status = "okay";
+                        xlnx,ip-name = "psv_scntrs";
+                        reg = <0x0 0xff140000 0x0 0x10000>;
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_scntrs_0";
+                        phandle = <0x57>;
+                };
+        };
+
+        psv_r5_0_atcm_global: psv_r5_0_atcm_global@ffe00000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800b>;
+                reg = <0x0 0xffe00000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,is-hierarchy;
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_atcm_global";
+                phandle = <0x6a>;
+        };
+
+        psv_r5_0_btcm_global: psv_r5_0_btcm_global@ffe20000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800c>;
+                reg = <0x0 0xffe20000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,is-hierarchy;
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_0_btcm_global";
+                phandle = <0x135>;
+        };
+
+        psv_r5_1_atcm_global: psv_r5_1_atcm_global@ffe90000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800d>;
+                reg = <0x0 0xffe90000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_atcm_global";
+                phandle = <0x6b>;
+        };
+
+        psv_r5_1_btcm_global: psv_r5_1_btcm_global@ffeb0000 {
+                compatible = "xlnx,psv-tcm-global-1.0", "mmio-sram";
+                power-domains = <&versal_firmware 0x1831800e>;
+                reg = <0x0 0xffeb0000 0x0 0x10000>;
+                xlnx,rable = <0x0>;
+                status = "okay";
+                xlnx,ip-name = "psv_tcm_global";
+                xlnx,name = "versal_cips_0_pspmc_0_psv_r5_1_btcm_global";
+                phandle = <0x6c>;
+        };
+
+        amba_xppu: indirect-bus@1 {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0x136>;
+
+                lpd_xppu: xppu@ff990000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xff990000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_lpd_xppu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_lpd_xppu_0";
+                        phandle = <0x5d>;
+                };
+
+                pmc_xppu: xppu@f1310000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf1310000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_xppu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_xppu_0";
+                        phandle = <0x3d>;
+                };
+
+                pmc_xppu_npi: xppu@f1300000 {
+                        compatible = "xlnx,xppu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf1300000 0x0 0x2000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_xppu_npi";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_xppu_npi_0";
+                        phandle = <0x3c>;
+                };
+        };
+
+        amba_xmpu: indirect-bus@2 {
+                compatible = "indirect-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                phandle = <0x137>;
+
+                fpd_xmpu: xmpu@fd390000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xfd390000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_fpd_slave_xmpu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_fpd_slave_xmpu_0";
+                        phandle = <0x46>;
+                };
+
+                pmc_xmpu: xmpu@f12f0000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf12f0000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_pmc_xmpu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_pmc_xmpu_0";
+                        phandle = <0x3b>;
+                };
+
+                ocm_xmpu: xmpu@ff980000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xff980000 0x0 0x1000>;
+                        status = "okay";
+                        xlnx,rable = <0x0>;
+                        xlnx,ip-name = "psv_ocm_xmpu";
+                        xlnx,name = "versal_cips_0_pspmc_0_psv_ocm_xmpu_0";
+                        phandle = <0x5c>;
+                };
+
+                ddrmc_xmpu_0: xmpu@f6080000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6080000 0x0 0x1000>;
+                        status = "okay";
+                        phandle = <0x138>;
+                };
+
+                ddrmc_xmpu_1: xmpu@f6220000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6220000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x139>;
+                };
+
+                ddrmc_xmpu_2: xmpu@f6390000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6390000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x13a>;
+                };
+
+                ddrmc_xmpu_3: xmpu@f6500000 {
+                        compatible = "xlnx,xmpu";
+                        #firewall-cells = <0x0>;
+                        reg = <0x0 0xf6500000 0x0 0x1000>;
+                        status = "disabled";
+                        phandle = <0x13b>;
+                };
+        };
+
+        pl_alt_ref_clk: pl_alt_ref_clk {
+                bootph-all;
+                compatible = "fixed-clock";
+                #clock-cells = <0x0>;
+                clock-frequency = <0x1fca055>;
+                phandle = <0x9b>;
+        };
+
+        ref_clk: ref_clk {
+                bootph-all;
+                compatible = "fixed-clock";
+                #clock-cells = <0x0>;
+                clock-frequency = <0x1fca055>;
+                phandle = <0x9a>;
+        };
+
+        can0_clk: can0_clk {
+                #clock-cells = <0x0>;
+                compatible = "fixed-factor-clock";
+                clocks = <&versal_clk 0x60>;
+                clock-div = <0x2>;
+                clock-mult = <0x1>;
+                phandle = <0x92>;
+        };
+
+        can1_clk: can1_clk {
+                #clock-cells = <0x0>;
+                compatible = "fixed-factor-clock";
+                clocks = <&versal_clk 0x61>;
+                clock-div = <0x2>;
+                clock-mult = <0x1>;
+                phandle = <0x93>;
+        };
+
+        firmware {
+
+                versal_firmware: versal-firmware {
+                        compatible = "xlnx,versal-firmware";
+                        interrupt-parent = <&imux>;
+                        bootph-all;
+                        method = "smc";
+                        #power-domain-cells = <0x1>;
+                        phandle = <0x75>;
+
+                        versal_clk: clock-controller {
+                                bootph-all;
+                                #clock-cells = <0x1>;
+                                compatible = "xlnx,versal-clk";
+                                clocks = <&ref_clk>,
+                                 <&pl_alt_ref_clk>;
+                                clock-names = "ref_clk", "pl_alt_ref_clk";
+                                phandle = <0x76>;
+                        };
+
+                        zynqmp_power: zynqmp-power {
+                                compatible = "xlnx,zynqmp-power";
+                                phandle = <0x13c>;
+                        };
+
+                        versal_reset: reset-controller {
+                                compatible = "xlnx,versal-reset";
+                                #reset-cells = <0x1>;
+                                phandle = <0x97>;
+                        };
+
+                        pinctrl0: pinctrl {
+                                compatible = "xlnx,versal-pinctrl";
+                                phandle = <0x13d>;
+                        };
+
+                        versal_sec_cfg: versal-sec-cfg {
+                                compatible = "xlnx,versal-sec-cfg";
+                                #address-cells = <0x1>;
+                                #size-cells = <0x1>;
+                                phandle = <0x13e>;
+
+                                bbram_zeroize: bbram-zeroize@4 {
+                                        reg = <0x4 0x4>;
+                                        phandle = <0x13f>;
+                                };
+
+                                bbram_key: bbram-key@10 {
+                                        reg = <0x10 0x20>;
+                                        phandle = <0x140>;
+                                };
+
+                                bbram_usr: bbram-usr@30 {
+                                        reg = <0x30 0x4>;
+                                        phandle = <0x141>;
+                                };
+
+                                bbram_lock: bbram-lock@48 {
+                                        reg = <0x48 0x4>;
+                                        phandle = <0x142>;
+                                };
+
+                                user_key0: user-key@110 {
+                                        reg = <0x110 0x20>;
+                                        phandle = <0x143>;
+                                };
+
+                                user_key1: user-key@130 {
+                                        reg = <0x130 0x20>;
+                                        phandle = <0x144>;
+                                };
+
+                                user_key2: user-key@150 {
+                                        reg = <0x150 0x20>;
+                                        phandle = <0x145>;
+                                };
+
+                                user_key3: user-key@170 {
+                                        reg = <0x170 0x20>;
+                                        phandle = <0x146>;
+                                };
+
+                                user_key4: user-key@190 {
+                                        reg = <0x190 0x20>;
+                                        phandle = <0x147>;
+                                };
+
+                                user_key5: user-key@1b0 {
+                                        reg = <0x1b0 0x20>;
+                                        phandle = <0x148>;
+                                };
+
+                                user_key6: user-key@1d0 {
+                                        reg = <0x1d0 0x20>;
+                                        phandle = <0x149>;
+                                };
+
+                                user_key7: user-key@1f0 {
+                                        reg = <0x1f0 0x20>;
+                                        phandle = <0x14a>;
+                                };
+                        };
+                };
+        };
+
+        amba_pl: amba_pl {
+                ranges;
+                compatible = "simple-bus";
+                #address-cells = <0x2>;
+                #size-cells = <0x2>;
+                firmware-name = "qdma-example-kula-vmk180-20260526.pdi";
+                phandle = <0x14b>;
+
+                misc_clk_0: misc_clk_0 {
+                        compatible = "fixed-clock";
+                        clock-frequency = <0xee6b280>;
+                        #clock-cells = <0x0>;
+                        phandle = <0x9c>;
+                };
+
+                axi_bram_ctrl_0: axi_bram_ctrl@0 {
+                        xlnx,protocol = "AXI4LITE";
+                        xlnx,edk-special = "BRAM_CTRL";
+                        compatible = "xlnx,axi-bram-ctrl-4.1";
+                        xlnx,ecc-onoff-reset-value = <0x0>;
+                        xlnx,ecc-type = <0x0>;
+                        xlnx,rd-cmd-optimization = <0x0>;
+                        xlnx,memory-depth = <0x400>;
+                        xlnx,use-ecc = <0x0>;
+                        xlnx,rable = <0x0>;
+                        xlnx,fault-inject = <0x0>;
+                        xlnx,ip-name = "axi_bram_ctrl";
+                        reg = <0x0 0x0 0x0 0x1000>;
+                        xlnx,bmg-instance = "EXTERNAL";
+                        clocks = <&misc_clk_0>;
+                        xlnx,s-axi-ctrl-addr-width = <0x20>;
+                        xlnx,read-latency = <0x1>;
+                        xlnx,id-width = <0x0>;
+                        xlnx,s-axi-supports-narrow-burst = <0x0>;
+                        xlnx,supports-narrow-burst = <0x0>;
+                        xlnx,single-port-bram = <0x1>;
+                        xlnx,ecc = <0x0>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        status = "okay";
+                        clock-names = "s_axi_aclk";
+                        xlnx,data-width = <0x20>;
+                        xlnx,bram-addr-width = <0xa>;
+                        xlnx,bram-inst-mode = "EXTERNAL";
+                        xlnx,s-axi-ctrl-data-width = <0x20>;
+                        xlnx,mem-depth = <0x400>;
+                        xlnx,s-axi-id-width = <0x1>;
+                        xlnx,name = "axi_bram_ctrl_0";
+                        phandle = <0x14c>;
+                };
+
+                axi_gpio_0: gpio@20200000000 {
+                        #interrupt-cells = <0x2>;
+                        interrupts = <0x0 0x5d 0x4>;
+                        xlnx,gpio-board-interface = "Custom";
+                        compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+                        xlnx,all-outputs = <0x0>;
+                        #gpio-cells = <0x2>;
+                        xlnx,gpio-width = <0x20>;
+                        interrupt-parent = <&imux>;
+                        xlnx,rable = <0x0>;
+                        xlnx,dout-default = <0x0>;
+                        xlnx,is-dual = <0x1>;
+                        xlnx,ip-name = "axi_gpio";
+                        xlnx,tri-default-2 = <0xffffffff>;
+                        reg = <0x202 0x0 0x0 0x10000>;
+                        xlnx,all-inputs-2 = <0x0>;
+                        clocks = <&misc_clk_0>;
+                        xlnx,all-outputs-2 = <0x1>;
+                        gpio-controller;
+                        xlnx,interrupt-present = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,dout-default-2 = <0x0>;
+                        status = "okay";
+                        xlnx,gpio2-width = <0x20>;
+                        clock-names = "s_axi_aclk";
+                        interrupt-controller;
+                        interrupt-names = "ip2intc_irpt";
+                        xlnx,tri-default = <0xffffffff>;
+                        xlnx,name = "axi_gpio_0";
+                        xlnx,all-inputs = <0x1>;
+                        phandle = <0x70>;
+                };
+
+                axi_gpio_1: gpio@20200010000 {
+                        #interrupt-cells = <0x2>;
+                        xlnx,gpio-board-interface = "Custom";
+                        compatible = "xlnx,axi-gpio-2.0", "xlnx,xps-gpio-1.00.a";
+                        xlnx,all-outputs = <0x0>;
+                        #gpio-cells = <0x2>;
+                        xlnx,gpio-width = <0x20>;
+                        xlnx,rable = <0x0>;
+                        xlnx,dout-default = <0x0>;
+                        xlnx,is-dual = <0x1>;
+                        xlnx,ip-name = "axi_gpio";
+                        xlnx,tri-default-2 = <0xffffffff>;
+                        reg = <0x202 0x10000 0x0 0x10000>;
+                        xlnx,all-inputs-2 = <0x0>;
+                        clocks = <&misc_clk_0>;
+                        xlnx,all-outputs-2 = <0x1>;
+                        gpio-controller;
+                        xlnx,interrupt-present = <0x1>;
+                        xlnx,gpio2-board-interface = "Custom";
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,dout-default-2 = <0x0>;
+                        status = "okay";
+                        xlnx,gpio2-width = <0x20>;
+                        clock-names = "s_axi_aclk";
+                        interrupt-controller;
+                        xlnx,tri-default = <0xffffffff>;
+                        xlnx,name = "axi_gpio_1";
+                        xlnx,all-inputs = <0x1>;
+                        phandle = <0x71>;
+                };
+
+                mailbox_0: mailbox@20180000000 {
+                        interrupts = <0x0 0x5c 0x4>;
+                        xlnx,s1-axi-aclk-freq-mhz = <0xfa>;
+                        compatible = "xlnx,mailbox-2.1";
+                        xlnx,interconnect-port-0 = <0x2>;
+                        xlnx,interconnect-port-1 = <0x2>;
+                        interrupt-parent = <&imux>;
+                        xlnx,rable = <0x0>;
+                        xlnx,mailbox-depth = <0x40>;
+                        xlnx,s1-axi-data-width = <0x20>;
+                        xlnx,s0-axi-addr-width = <0x20>;
+                        xlnx,ip-name = "mailbox";
+                        reg = <0x201 0x80000000 0x0 0x10000 0x201 0x80010000 0x0 0x10000>;
+                        xlnx,async-clks = <0x0>;
+                        xlnx,impl-style = <0x0>;
+                        clocks = <&misc_clk_0>,
+                         <&misc_clk_0>;
+                        xlnx,read-clock-period-0 = <0x0>;
+                        xlnx,read-clock-period-1 = <0x0>;
+                        xlnx,num-sync-ff = <0x2>;
+                        xlnx,async-interrupts = <0x1>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,enable-bus-error = <0x0>;
+                        xlnx,s0-axi-data-width = <0x20>;
+                        status = "okay";
+                        xlnx,ext-reset-high = <0x1>;
+                        clock-names = "S0_AXI_ACLK", "S1_AXI_ACLK";
+                        interrupt-names = "Interrupt_0";
+                        xlnx,s1-axi-addr-width = <0x20>;
+                        xlnx,s0-axi-aclk-freq-mhz = <0xfa>;
+                        xlnx,name = "mailbox_0";
+                        phandle = <0x6f>;
+                };
+
+                pcie_qdma_mailbox_0: pcie_qdma_mailbox@20800000000 {
+                        xlnx,num-vfs-pf3 = <0x3c>;
+                        compatible = "xlnx,pcie-qdma-mailbox-1.0";
+                        xlnx,patch-revision = <0x20140001>;
+                        xlnx,rtl-revision = <0x1fd31000>;
+                        xlnx,rable = <0x0>;
+                        xlnx,h10-device = <0x0>;
+                        xlnx,ip-name = "pcie_qdma_mailbox";
+                        xlnx,total-fnc = <0x100>;
+                        reg = <0x208 0x0 0x0 0x80000000>;
+                        clocks = <&misc_clk_0>,
+                         <&misc_clk_0>;
+                        xlnx,max-pf = <0x4>;
+                        xlnx,edk-iptype = "PERIPHERAL";
+                        xlnx,mailbox-opt;
+                        xlnx,versal;
+                        status = "okay";
+                        xlnx,num-pfs = <0x4>;
+                        clock-names = "axi_aclk", "ip_clk";
+                        xlnx,num-vfs-pf0 = <0x40>;
+                        xlnx,num-vfs-pf1 = <0x40>;
+                        xlnx,vf-4kq = <0x0>;
+                        xlnx,num-vfs-pf2 = <0x40>;
+                        xlnx,name = "pcie_qdma_mailbox_0";
+                        phandle = <0x72>;
+                };
+        };
+
+        axi_noc_0_ddr_memory: memory@00000000 {
+                compatible = "xlnx,axi-noc-1.1";
+                xlnx,ip-name = "axi_noc";
+                device_type = "memory";
+                reg = <0x0 0x0 0x0 0x80000000>;
+                memory_type = "memory";
+                phandle = <0x3>;
+        };
+
+        versal_cips_0_pspmc_0_psv_ocm_ram_0_memory: memory@FFFC0000 {
+                compatible = "xlnx,psv-ocm-ram-0-1.0", "mmio-sram";
+                xlnx,ip-name = "psv_ocm_ram_0";
+                device_type = "memory";
+                memory_type = "memory";
+                reg = <0x0 0xfffc0000 0x0 0x40000>;
+                phandle = <0xc>;
+        };
+
+        chosen {
+                stdout-path = "serial0:115200";
+                bootargs = "console=ttyAMA0 earlycon=pl011,mmio32,0xFF000000,115200n8 clk_ignore_unused";
+        };
+
+        aliases {
+                serial0 = "/axi/serial@ff000000";
+                spi0 = "/axi/spi@f1030000";
+                serial1 = "/axi/coresight@f0800000";
+                i2c0 = "/axi/i2c@ff020000";
+                ethernet0 = "/axi/ethernet@ff0c0000";
+                serial2 = "/dcc";
+                ethernet1 = "/axi/ethernet@ff0d0000";
+                i2c1 = "/axi/i2c@ff030000";
+                mmc0 = "/axi/mmc@f1050000";
+                usb0 = "/axi/usb@ff9d0000";
+                rtc0 = "/axi/rtc@f12a0000";
+        };
+
+        __symbols__ {
+                cpus_a72 = "/cpus-a72@0";
+                psv_cortexa72_0 = "/cpus-a72@0/cpu@0";
+                psv_cortexa72_1 = "/cpus-a72@0/cpu@1";
+                CPU_SLEEP_0 = "/cpus-a72@0/idle-states/cpu-sleep-0";
+                cpus_microblaze_0 = "/cpus_microblaze@0";
+                psv_pmc_0 = "/cpus_microblaze@0/cpu@0";
+                cpus_microblaze_1 = "/cpus_microblaze@1";
+                psv_psm_0 = "/cpus_microblaze@1/cpu@0";
+                cpus_r5_0 = "/cpus-r5@0";
+                psv_cortexr5_0 = "/cpus-r5@0/cpu@0";
+                cpus_r5_1 = "/cpus-r5@1";
+                psv_cortexr5_1 = "/cpus-r5@1/cpu@1";
+                cpu_opp_table = "/opp-table-cpu";
+                dcc = "/dcc";
+                fpga = "/fpga-region";
+                psci = "/psci";
+                timer = "/timer";
+                versal_fpga = "/versal-fpga";
+                sensor0 = "/versal-thermal-sensor";
+                versal_thermal = "/thermal-zones/versal-thermal";
+                temp_alert = "/thermal-zones/versal-thermal/trips/temp-alert";
+                ot_crit = "/thermal-zones/versal-thermal/trips/ot-crit";
+                amba_apu = "/apu-bus";
+                gic_a72 = "/apu-bus/interrupt-controller@f9000000";
+                gic_its = "/apu-bus/interrupt-controller@f9000000/msi-controller@f9020000";
+                amba_rpu = "/rpu-bus";
+                gic_r5 = "/rpu-bus/interrupt-controller@f9000000";
+                amba = "/axi";
+                imux = "/axi/interrupt-multiplex";
+                can0 = "/axi/can@ff060000";
+                can1 = "/axi/can@ff070000";
+                cci = "/axi/cci@fd000000";
+                cci_pmu = "/axi/cci@fd000000/pmu@10000";
+                lpd_dma_chan0 = "/axi/dma-controller@ffa80000";
+                lpd_dma_chan1 = "/axi/dma-controller@ffa90000";
+                lpd_dma_chan2 = "/axi/dma-controller@ffaa0000";
+                lpd_dma_chan3 = "/axi/dma-controller@ffab0000";
+                lpd_dma_chan4 = "/axi/dma-controller@ffac0000";
+                lpd_dma_chan5 = "/axi/dma-controller@ffad0000";
+                lpd_dma_chan6 = "/axi/dma-controller@ffae0000";
+                lpd_dma_chan7 = "/axi/dma-controller@ffaf0000";
+                gem0 = "/axi/ethernet@ff0c0000";
+                mdio = "/axi/ethernet@ff0c0000/mdio";
+                phy1 = "/axi/ethernet@ff0c0000/mdio/ethernet-phy@1";
+                phy2 = "/axi/ethernet@ff0c0000/mdio/ethernet-phy@2";
+                gem1 = "/axi/ethernet@ff0d0000";
+                gpio0 = "/axi/gpio@ff0b0000";
+                gpio1 = "/axi/gpio@f1020000";
+                i2c0 = "/axi/i2c@ff020000";
+                i2c1 = "/axi/i2c@ff030000";
+                i2c2 = "/axi/i2c@f1000000";
+                mc0 = "/axi/memory-controller@f6150000";
+                mc1 = "/axi/memory-controller@f62c0000";
+                mc2 = "/axi/memory-controller@f6430000";
+                mc3 = "/axi/memory-controller@f65a0000";
+                ocm = "/axi/memory-controller@ff960000";
+                rtc = "/axi/rtc@f12a0000";
+                sdhci0 = "/axi/mmc@f1040000";
+                sdhci1 = "/axi/mmc@f1050000";
+                serial0 = "/axi/serial@ff000000";
+                serial1 = "/axi/serial@ff010000";
+                smmu = "/axi/iommu@fd800000";
+                ospi = "/axi/spi@f1010000";
+                qspi = "/axi/spi@f1030000";
+                spi0 = "/axi/spi@ff040000";
+                spi1 = "/axi/spi@ff050000";
+                sysmon0 = "/axi/sysmon@f1270000";
+                sysmon1 = "/axi/sysmon@109270000";
+                sysmon2 = "/axi/sysmon@111270000";
+                sysmon3 = "/axi/sysmon@119270000";
+                ttc0 = "/axi/timer@ff0e0000";
+                ttc1 = "/axi/timer@ff0f0000";
+                ttc2 = "/axi/timer@ff100000";
+                ttc3 = "/axi/timer@ff110000";
+                usb0 = "/axi/usb@ff9d0000";
+                dwc3_0 = "/axi/usb@ff9d0000/usb@fe200000";
+                cpm_pciea = "/axi/pci@fca10000";
+                pcie_intc_0 = "/axi/pci@fca10000/interrupt-controller";
+                cpm5_pcie = "/axi/pcie@fcdd0000";
+                pcie_intc_2 = "/axi/pcie@fcdd0000/interrupt-controller";
+                watchdog = "/axi/watchdog@fd4d0000";
+                watchdog1 = "/axi/watchdog@ff120000";
+                xilsem_edac = "/axi/edac@f2014050";
+                dma0 = "/axi/pmcdma@f11c0000";
+                dma1 = "/axi/pmcdma@f11d0000";
+                iomodule0 = "/axi/iomodule@f0280000";
+                ipi_pmc = "/axi/mailbox@ff320000";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_0 = "/axi/mailbox@ff320000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_1 = "/axi/mailbox@ff320000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_2 = "/axi/mailbox@ff320000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_3 = "/axi/mailbox@ff320000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_4 = "/axi/mailbox@ff320000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_5 = "/axi/mailbox@ff320000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_6 = "/axi/mailbox@ff320000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_7 = "/axi/mailbox@ff320000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_8 = "/axi/mailbox@ff320000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_9 = "/axi/mailbox@ff320000/child@9";
+                ipi_pmc_nobuf = "/axi/mailbox@ff390000";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_0 = "/axi/mailbox@ff390000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_1 = "/axi/mailbox@ff390000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_2 = "/axi/mailbox@ff390000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_3 = "/axi/mailbox@ff390000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_4 = "/axi/mailbox@ff390000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_5 = "/axi/mailbox@ff390000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_6 = "/axi/mailbox@ff390000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_7 = "/axi/mailbox@ff390000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_8 = "/axi/mailbox@ff390000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_pmc_nobuf_9 = "/axi/mailbox@ff390000/child@9";
+                ipi_psm = "/axi/mailbox@ff310000";
+                versal_cips_0_pspmc_0_psv_ipi_psm_0 = "/axi/mailbox@ff310000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_psm_1 = "/axi/mailbox@ff310000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_psm_2 = "/axi/mailbox@ff310000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_psm_3 = "/axi/mailbox@ff310000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_psm_4 = "/axi/mailbox@ff310000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_psm_5 = "/axi/mailbox@ff310000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_psm_6 = "/axi/mailbox@ff310000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_psm_7 = "/axi/mailbox@ff310000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_psm_8 = "/axi/mailbox@ff310000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_psm_9 = "/axi/mailbox@ff310000/child@9";
+                ipi0 = "/axi/mailbox@ff330000";
+                versal_cips_0_pspmc_0_psv_ipi_0_0 = "/axi/mailbox@ff330000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_0_1 = "/axi/mailbox@ff330000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_0_2 = "/axi/mailbox@ff330000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_0_3 = "/axi/mailbox@ff330000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_0_4 = "/axi/mailbox@ff330000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_0_5 = "/axi/mailbox@ff330000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_0_6 = "/axi/mailbox@ff330000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_0_7 = "/axi/mailbox@ff330000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_0_8 = "/axi/mailbox@ff330000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_0_9 = "/axi/mailbox@ff330000/child@9";
+                ipi1 = "/axi/mailbox@ff340000";
+                versal_cips_0_pspmc_0_psv_ipi_1_0 = "/axi/mailbox@ff340000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_1_1 = "/axi/mailbox@ff340000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_1_2 = "/axi/mailbox@ff340000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_1_3 = "/axi/mailbox@ff340000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_1_4 = "/axi/mailbox@ff340000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_1_5 = "/axi/mailbox@ff340000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_1_6 = "/axi/mailbox@ff340000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_1_7 = "/axi/mailbox@ff340000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_1_8 = "/axi/mailbox@ff340000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_1_9 = "/axi/mailbox@ff340000/child@9";
+                ipi2 = "/axi/mailbox@ff350000";
+                versal_cips_0_pspmc_0_psv_ipi_2_0 = "/axi/mailbox@ff350000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_2_1 = "/axi/mailbox@ff350000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_2_2 = "/axi/mailbox@ff350000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_2_3 = "/axi/mailbox@ff350000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_2_4 = "/axi/mailbox@ff350000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_2_5 = "/axi/mailbox@ff350000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_2_6 = "/axi/mailbox@ff350000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_2_7 = "/axi/mailbox@ff350000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_2_8 = "/axi/mailbox@ff350000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_2_9 = "/axi/mailbox@ff350000/child@9";
+                ipi3 = "/axi/mailbox@ff360000";
+                versal_cips_0_pspmc_0_psv_ipi_3_0 = "/axi/mailbox@ff360000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_3_1 = "/axi/mailbox@ff360000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_3_2 = "/axi/mailbox@ff360000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_3_3 = "/axi/mailbox@ff360000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_3_4 = "/axi/mailbox@ff360000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_3_5 = "/axi/mailbox@ff360000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_3_6 = "/axi/mailbox@ff360000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_3_7 = "/axi/mailbox@ff360000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_3_8 = "/axi/mailbox@ff360000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_3_9 = "/axi/mailbox@ff360000/child@9";
+                ipi4 = "/axi/mailbox@ff370000";
+                versal_cips_0_pspmc_0_psv_ipi_4_0 = "/axi/mailbox@ff370000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_4_1 = "/axi/mailbox@ff370000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_4_2 = "/axi/mailbox@ff370000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_4_3 = "/axi/mailbox@ff370000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_4_4 = "/axi/mailbox@ff370000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_4_5 = "/axi/mailbox@ff370000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_4_6 = "/axi/mailbox@ff370000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_4_7 = "/axi/mailbox@ff370000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_4_8 = "/axi/mailbox@ff370000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_4_9 = "/axi/mailbox@ff370000/child@9";
+                ipi5 = "/axi/mailbox@ff380000";
+                versal_cips_0_pspmc_0_psv_ipi_5_0 = "/axi/mailbox@ff380000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_5_1 = "/axi/mailbox@ff380000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_5_2 = "/axi/mailbox@ff380000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_5_3 = "/axi/mailbox@ff380000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_5_4 = "/axi/mailbox@ff380000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_5_5 = "/axi/mailbox@ff380000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_5_6 = "/axi/mailbox@ff380000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_5_7 = "/axi/mailbox@ff380000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_5_8 = "/axi/mailbox@ff380000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_5_9 = "/axi/mailbox@ff380000/child@9";
+                ipi6 = "/axi/mailbox@ff3a0000";
+                versal_cips_0_pspmc_0_psv_ipi_6_0 = "/axi/mailbox@ff3a0000/child@0";
+                versal_cips_0_pspmc_0_psv_ipi_6_1 = "/axi/mailbox@ff3a0000/child@1";
+                versal_cips_0_pspmc_0_psv_ipi_6_2 = "/axi/mailbox@ff3a0000/child@2";
+                versal_cips_0_pspmc_0_psv_ipi_6_3 = "/axi/mailbox@ff3a0000/child@3";
+                versal_cips_0_pspmc_0_psv_ipi_6_4 = "/axi/mailbox@ff3a0000/child@4";
+                versal_cips_0_pspmc_0_psv_ipi_6_5 = "/axi/mailbox@ff3a0000/child@5";
+                versal_cips_0_pspmc_0_psv_ipi_6_6 = "/axi/mailbox@ff3a0000/child@6";
+                versal_cips_0_pspmc_0_psv_ipi_6_7 = "/axi/mailbox@ff3a0000/child@7";
+                versal_cips_0_pspmc_0_psv_ipi_6_8 = "/axi/mailbox@ff3a0000/child@8";
+                versal_cips_0_pspmc_0_psv_ipi_6_9 = "/axi/mailbox@ff3a0000/child@9";
+                coresight = "/axi/coresight@f0800000";
+                versal_cips_0_cpm_0_psv_cpm = "/axi/versal_cips_0_cpm_0_psv_cpm@0";
+                versal_cips_0_pspmc_0_psv_apu_0 = "/axi/versal_cips_0_pspmc_0_psv_apu_0@fd5c0000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_cti = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_cti@f0d10000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_dbg = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_dbg@f0d00000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_etm = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_etm@f0d30000";
+                versal_cips_0_pspmc_0_psv_coresight_a720_pmu = "/axi/versal_cips_0_pspmc_0_psv_coresight_a720_pmu@f0d20000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_cti = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_cti@f0d50000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_dbg = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_dbg@f0d40000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_etm = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_etm@f0d70000";
+                versal_cips_0_pspmc_0_psv_coresight_a721_pmu = "/axi/versal_cips_0_pspmc_0_psv_coresight_a721_pmu@f0d60000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_cti = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_cti@f0ca0000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_ela = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_ela@f0c60000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_etf = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_etf@f0c30000";
+                versal_cips_0_pspmc_0_psv_coresight_apu_fun = "/axi/versal_cips_0_pspmc_0_psv_coresight_apu_fun@f0c20000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_atm = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_atm@f0f80000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_cti2a@f0fa0000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_cti2d@f0fd0000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2a@f0f40000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2b@f0f50000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2c@f0f60000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_ela2d@f0f70000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_fun = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_fun@f0f20000";
+                versal_cips_0_pspmc_0_psv_coresight_cpm_rom = "/axi/versal_cips_0_pspmc_0_psv_coresight_cpm_rom@f0f00000";
+                versal_cips_0_pspmc_0_psv_coresight_fpd_atm = "/axi/versal_cips_0_pspmc_0_psv_coresight_fpd_atm@f0b80000";
+                versal_cips_0_pspmc_0_psv_coresight_fpd_stm = "/axi/versal_cips_0_pspmc_0_psv_coresight_fpd_stm@f0b70000";
+                versal_cips_0_pspmc_0_psv_coresight_lpd_atm = "/axi/versal_cips_0_pspmc_0_psv_coresight_lpd_atm@f0980000";
+                versal_cips_0_pspmc_0_psv_crf_0 = "/axi/versal_cips_0_pspmc_0_psv_crf_0@fd1a0000";
+                versal_cips_0_pspmc_0_psv_crl_0 = "/axi/versal_cips_0_pspmc_0_psv_crl_0@ff5e0000";
+                versal_cips_0_pspmc_0_psv_crp_0 = "/axi/versal_cips_0_pspmc_0_psv_crp_0@f1260000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_0@fd360000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_2 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_2@fd380000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_mem_0@a4000000";
+                versal_cips_0_pspmc_0_psv_fpd_afi_mem_2 = "/axi/versal_cips_0_pspmc_0_psv_fpd_afi_mem_2@b0000000";
+                versal_cips_0_pspmc_0_psv_fpd_cci_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_cci_0@fd5e0000";
+                versal_cips_0_pspmc_0_psv_fpd_gpv_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_gpv_0@fd700000";
+                versal_cips_0_pspmc_0_psv_fpd_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_slcr_0@fd610000";
+                versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_slcr_secure_0@fd690000";
+                versal_cips_0_pspmc_0_psv_fpd_smmu_0 = "/axi/versal_cips_0_pspmc_0_psv_fpd_smmu_0@fd5f0000";
+                versal_cips_0_pspmc_0_psv_ipi_buffer = "/axi/versal_cips_0_pspmc_0_psv_ipi_buffer@ff3f0000";
+                versal_cips_0_pspmc_0_psv_lpd_afi_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_afi_0@ff9b0000";
+                versal_cips_0_pspmc_0_psv_lpd_afi_mem_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_afi_mem_0@80000000";
+                versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_iou_secure_slcr_0@ff0a0000";
+                versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_iou_slcr_0@ff080000";
+                versal_cips_0_pspmc_0_psv_lpd_slcr_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_slcr_0@ff410000";
+                versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0 = "/axi/versal_cips_0_pspmc_0_psv_lpd_slcr_secure_0@ff510000";
+                versal_cips_0_pspmc_0_psv_noc_pcie_0 = "/axi/versal_cips_0_pspmc_0_psv_noc_pcie_0@e0000000";
+                versal_cips_0_pspmc_0_psv_noc_pcie_1 = "/axi/versal_cips_0_pspmc_0_psv_noc_pcie_1@600000000";
+                versal_cips_0_pspmc_0_psv_noc_pcie_2 = "/axi/versal_cips_0_pspmc_0_psv_noc_pcie_2@8000000000";
+                versal_cips_0_pspmc_0_psv_ocm_ctrl = "/axi/versal_cips_0_pspmc_0_psv_ocm_ctrl@ff960000";
+                versal_cips_0_pspmc_0_psv_pmc_aes = "/axi/versal_cips_0_pspmc_0_psv_pmc_aes@f11e0000";
+                versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl = "/axi/versal_cips_0_pspmc_0_psv_pmc_bbram_ctrl@f11f0000";
+                versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_cfi_cframe_0@f12d0000";
+                versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_cfu_apb_0@f12b0000";
+                versal_cips_0_pspmc_0_psv_pmc_efuse_cache = "/axi/versal_cips_0_pspmc_0_psv_pmc_efuse_cache@f1250000";
+                versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl = "/axi/versal_cips_0_pspmc_0_psv_pmc_efuse_ctrl@f1240000";
+                versal_cips_0_pspmc_0_psv_pmc_global_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_global_0@f1110000";
+                versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_ppu1_mdm_0@f0310000";
+                versal_cips_0_pspmc_0_psv_pmc_ram = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram@f2000000";
+                versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram_data_cntlr@f0240000";
+                versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram_instr_cntlr@f0200000";
+                versal_cips_0_pspmc_0_psv_pmc_ram_npi = "/axi/versal_cips_0_pspmc_0_psv_pmc_ram_npi@f6000000";
+                versal_cips_0_pspmc_0_psv_pmc_rsa = "/axi/versal_cips_0_pspmc_0_psv_pmc_rsa@f1200000";
+                versal_cips_0_pspmc_0_psv_pmc_sha = "/axi/versal_cips_0_pspmc_0_psv_pmc_sha@f1210000";
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot = "/axi/versal_cips_0_pspmc_0_psv_pmc_slave_boot@f1220000";
+                versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream = "/axi/versal_cips_0_pspmc_0_psv_pmc_slave_boot_stream@f2100000";
+                versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_tmr_inject_0@f0083000";
+                versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0 = "/axi/versal_cips_0_pspmc_0_psv_pmc_tmr_manager_0@f0283000";
+                versal_cips_0_pspmc_0_psv_pmc_trng = "/axi/versal_cips_0_pspmc_0_psv_pmc_trng@f1230000";
+                versal_cips_0_pspmc_0_psv_psm_global_reg = "/axi/versal_cips_0_pspmc_0_psv_psm_global_reg@ffc90000";
+                versal_cips_0_pspmc_0_psv_psm_iomodule_0 = "/axi/versal_cips_0_pspmc_0_psv_psm_iomodule_0@ffc80000";
+                versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr = "/axi/versal_cips_0_pspmc_0_psv_psm_ram_data_cntlr@ffc20000";
+                versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr = "/axi/versal_cips_0_pspmc_0_psv_psm_ram_instr_cntlr@ffc00000";
+                versal_cips_0_pspmc_0_psv_psm_tmr_inject_0 = "/axi/versal_cips_0_pspmc_0_psv_psm_tmr_inject_0@ffcd0000";
+                versal_cips_0_pspmc_0_psv_psm_tmr_manager_0 = "/axi/versal_cips_0_pspmc_0_psv_psm_tmr_manager_0@ffcc0000";
+                versal_cips_0_pspmc_0_psv_r5_0_atcm = "/axi/versal_cips_0_pspmc_0_psv_r5_0_atcm@0";
+                versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep = "/axi/versal_cips_0_pspmc_0_psv_r5_0_atcm_lockstep@ffe10000";
+                versal_cips_0_pspmc_0_psv_r5_0_btcm = "/axi/versal_cips_0_pspmc_0_psv_r5_0_btcm@20000";
+                versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep = "/axi/versal_cips_0_pspmc_0_psv_r5_0_btcm_lockstep@ffe30000";
+                versal_cips_0_pspmc_0_psv_r5_0_data_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_0_data_cache@ffe50000";
+                versal_cips_0_pspmc_0_psv_r5_0_instruction_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_0_instruction_cache@ffe40000";
+                versal_cips_0_pspmc_0_psv_r5_1_atcm = "/axi/versal_cips_0_pspmc_0_psv_r5_1_atcm@0";
+                versal_cips_0_pspmc_0_psv_r5_1_btcm = "/axi/versal_cips_0_pspmc_0_psv_r5_1_btcm@20000";
+                versal_cips_0_pspmc_0_psv_r5_1_data_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_1_data_cache@ffed0000";
+                versal_cips_0_pspmc_0_psv_r5_1_instruction_cache = "/axi/versal_cips_0_pspmc_0_psv_r5_1_instruction_cache@ffec0000";
+                versal_cips_0_pspmc_0_psv_r5_tcm_ram_0 = "/axi/versal_cips_0_pspmc_0_psv_r5_tcm_ram_0@0";
+                versal_cips_0_pspmc_0_psv_rpu_0 = "/axi/versal_cips_0_pspmc_0_psv_rpu_0@ff9a0000";
+                versal_cips_0_pspmc_0_psv_scntr_0 = "/axi/versal_cips_0_pspmc_0_psv_scntr_0@ff130000";
+                versal_cips_0_pspmc_0_psv_scntrs_0 = "/axi/versal_cips_0_pspmc_0_psv_scntrs_0@ff140000";
+                psv_r5_0_atcm_global = "/psv_r5_0_atcm_global@ffe00000";
+                psv_r5_0_btcm_global = "/psv_r5_0_btcm_global@ffe20000";
+                psv_r5_1_atcm_global = "/psv_r5_1_atcm_global@ffe90000";
+                psv_r5_1_btcm_global = "/psv_r5_1_btcm_global@ffeb0000";
+                amba_xppu = "/indirect-bus@1";
+                lpd_xppu = "/indirect-bus@1/xppu@ff990000";
+                pmc_xppu = "/indirect-bus@1/xppu@f1310000";
+                pmc_xppu_npi = "/indirect-bus@1/xppu@f1300000";
+                amba_xmpu = "/indirect-bus@2";
+                fpd_xmpu = "/indirect-bus@2/xmpu@fd390000";
+                pmc_xmpu = "/indirect-bus@2/xmpu@f12f0000";
+                ocm_xmpu = "/indirect-bus@2/xmpu@ff980000";
+                ddrmc_xmpu_0 = "/indirect-bus@2/xmpu@f6080000";
+                ddrmc_xmpu_1 = "/indirect-bus@2/xmpu@f6220000";
+                ddrmc_xmpu_2 = "/indirect-bus@2/xmpu@f6390000";
+                ddrmc_xmpu_3 = "/indirect-bus@2/xmpu@f6500000";
+                pl_alt_ref_clk = "/pl_alt_ref_clk";
+                ref_clk = "/ref_clk";
+                can0_clk = "/can0_clk";
+                can1_clk = "/can1_clk";
+                versal_firmware = "/firmware/versal-firmware";
+                versal_clk = "/firmware/versal-firmware/clock-controller";
+                zynqmp_power = "/firmware/versal-firmware/zynqmp-power";
+                versal_reset = "/firmware/versal-firmware/reset-controller";
+                pinctrl0 = "/firmware/versal-firmware/pinctrl";
+                versal_sec_cfg = "/firmware/versal-firmware/versal-sec-cfg";
+                bbram_zeroize = "/firmware/versal-firmware/versal-sec-cfg/bbram-zeroize@4";
+                bbram_key = "/firmware/versal-firmware/versal-sec-cfg/bbram-key@10";
+                bbram_usr = "/firmware/versal-firmware/versal-sec-cfg/bbram-usr@30";
+                bbram_lock = "/firmware/versal-firmware/versal-sec-cfg/bbram-lock@48";
+                user_key0 = "/firmware/versal-firmware/versal-sec-cfg/user-key@110";
+                user_key1 = "/firmware/versal-firmware/versal-sec-cfg/user-key@130";
+                user_key2 = "/firmware/versal-firmware/versal-sec-cfg/user-key@150";
+                user_key3 = "/firmware/versal-firmware/versal-sec-cfg/user-key@170";
+                user_key4 = "/firmware/versal-firmware/versal-sec-cfg/user-key@190";
+                user_key5 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1b0";
+                user_key6 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1d0";
+                user_key7 = "/firmware/versal-firmware/versal-sec-cfg/user-key@1f0";
+                amba_pl = "/amba_pl";
+                misc_clk_0 = "/amba_pl/misc_clk_0";
+                axi_bram_ctrl_0 = "/amba_pl/axi_bram_ctrl@0";
+                axi_gpio_0 = "/amba_pl/gpio@20200000000";
+                axi_gpio_1 = "/amba_pl/gpio@20200010000";
+                mailbox_0 = "/amba_pl/mailbox@20180000000";
+                pcie_qdma_mailbox_0 = "/amba_pl/pcie_qdma_mailbox@20800000000";
+                axi_noc_0_ddr_memory = "/memory@00000000";
+                versal_cips_0_pspmc_0_psv_ocm_ram_0_memory = "/memory@FFFC0000";
+        };
+};

--- a/meta-nile/conf/dts/kula-vmk180/system-user.dtsi
+++ b/meta-nile/conf/dts/kula-vmk180/system-user.dtsi
@@ -1,0 +1,35 @@
+/ {
+	aliases {
+		serial0 = &serial0;
+		serial1 = &dcc;
+		serial2 = &serial1;
+		spi0 = &ospi;
+	};
+
+	memoryaxi_noc_0_ddr: memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x00000000 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		pcie_enet_mem: buffer@70000000 {
+			no-map;
+			reg = <0x00 0x70000000 0x00 0x800000>;
+		};
+	};
+
+
+};
+
+&fpga {
+	hostarmnet0: ethernet@70000000 {
+		compatible = "ni,host-arm-net";
+		reg = <0x00 0x70000000 0x00 0x100000>;
+
+		status = "okay";
+	};
+};

--- a/meta-nile/conf/machine/kula-vmk180.conf
+++ b/meta-nile/conf/machine/kula-vmk180.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: kula-vmk180
+#@DESCRIPTION: VMK180 machine configuration derived from kula.
+
+# Inherit common Kula machine settings.
+require conf/machine/kula.conf
+
+# VMK180 SDT source and artifact names.
+SDT_URI = "git://dev.azure.com/ni/Users/_git/kula-vivado;protocol=https;branch=vmk180;rev=8875c19ac1f389b6695904c56ad9a3f81f5ccd10"
+SDT_URI[S] = "${WORKDIR}/git/qdma_example_kula/generated/sdt"
+PDI_PATH = "${PDI_PATH_DIR}/qdma-example-kula-vmk180-20260526.pdi"

--- a/meta-nile/conf/machine/kula.conf
+++ b/meta-nile/conf/machine/kula.conf
@@ -21,7 +21,7 @@ PSM_MCDEPENDS = "mc::kula-microblaze-psm:psm-firmware:do_deploy"
 PSM_FIRMWARE_DEPLOY_DIR = "${TMPDIR}-kula-microblaze-psm/deploy/images/${MACHINE}"
 
 # Set the default (linux) domain device tree
-CONFIG_DTFILE_DIR := "${@bb.utils.which(d.getVar('BBPATH'), 'conf/dts/kula')}"
+CONFIG_DTFILE_DIR := "${@bb.utils.which(d.getVar('BBPATH'), 'conf/dts/${MACHINE}')}"
 CONFIG_DTFILE ?= "${CONFIG_DTFILE_DIR}/cortexa72-linux.dts"
 CONFIG_DTFILE[vardepsexclude] += "CONFIG_DTFILE_DIR"
 EXTRA_DT_INCLUDE_FILES += "${CONFIG_DTFILE_DIR}/system-user.dtsi"


### PR DESCRIPTION
We have two versal eval boards currently. The vck190 that kula has been targeting and the vmk180 with support added by this commit. Creating kula-vmk180 variant that pulls in the vmk180 design PDI and DTS files.