### PR TITLE
Add wic artifact for sd card booting eval boards

### DIFF
--- a/kas/targets/nile-image-dev_kula-vmk180.yml
+++ b/kas/targets/nile-image-dev_kula-vmk180.yml
@@ -14,6 +14,7 @@ artifacts:
   "nile-image-dev-kula-vmk180.rootfs.cpio.gz.u-boot": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.cpio.gz.u-boot"
   "nile-image-dev-kula-vmk180.rootfs.tar.gz": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.tar.gz"
   "nile-image-dev-kula-vmk180.rootfs.qemuboot.conf": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.qemuboot.conf"
+  "sdcard/nile-image-dev-kula-vmk180.rootfs.wic": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.wic"
   "qemu/nile-image-dev-kula-vmk180.rootfs.wic.qemu-sd": "tmp/deploy/images/kula-vmk180/nile-image-dev-kula-vmk180.rootfs.wic.qemu-sd"
   "qemu/plm-kula-vmk180.elf": "tmp/deploy/images/kula-vmk180/plm-kula-vmk180.elf"
   "qemu/cortexa72-linux.dtb": "tmp/deploy/images/kula-vmk180/devicetree/cortexa72-linux.dtb"

--- a/kas/targets/nile-image-dev_kula.yml
+++ b/kas/targets/nile-image-dev_kula.yml
@@ -14,6 +14,7 @@ artifacts:
   "nile-image-dev-kula.rootfs.cpio.gz.u-boot": "tmp/deploy/images/kula/nile-image-dev-kula.rootfs.cpio.gz.u-boot"
   "nile-image-dev-kula.rootfs.tar.gz": "tmp/deploy/images/kula/nile-image-dev-kula.rootfs.tar.gz"
   "nile-image-dev-kula.rootfs.qemuboot.conf": "tmp/deploy/images/kula/nile-image-dev-kula.rootfs.qemuboot.conf"
+  "sdcard/nile-image-dev-kula.rootfs.wic": "tmp/deploy/images/kula/nile-image-dev-kula.rootfs.wic"
   "qemu/nile-image-dev-kula.rootfs.wic.qemu-sd": "tmp/deploy/images/kula/nile-image-dev-kula.rootfs.wic.qemu-sd"
   "qemu/plm-kula.elf": "tmp/deploy/images/kula/plm-kula.elf"
   "qemu/cortexa72-linux.dtb": "tmp/deploy/images/kula/devicetree/cortexa72-linux.dtb"

--- a/meta-nile/conf/machine/kula.conf
+++ b/meta-nile/conf/machine/kula.conf
@@ -83,6 +83,9 @@ FIT_DTB_IMAGE_NAME = "fdt-${FIT_CONF_FDT}"
 # Use a non-default disk partition layout.
 WKS_FILES = "iba.wks"
 
+# Generate WIC images for both QEMU and real hardware
+IMAGE_FSTYPES += "wic"
+
 # Even though we are using a wks file, tell wic not to update the fstab file but leave it
 # alone. This way we get the same fstab file in our .wic[.qemu-sd] images that we get in
 # our RAUC update bundles.
@@ -104,6 +107,10 @@ KERNEL_ROOT_SD = "root=/dev/${bootdev}${rootfs_partition} ro rootwait rauc.slot=
 # Units are kbytes.
 KERNEL_PARTITION_SIZE = "204800"
 ROOTFS_PARTITION_SIZE = "614400"
+
+# Workaround to get the PL running and able to respond to PCIe reset. Inject these
+# register writes at @@PRE_BOOTENV@@ in boot.scr.
+PRE_BOOTENV = "mw.l 0xFCA50E80 0x3; mw.l 0xFCA50E80 0x0; mw.l 0xFCA50E84 0x1"
 
 ### No additional settings should be after the Postamble
 #### Postamble


### PR DESCRIPTION
The wic artifact is needed to partition the sd card with the nile build for booting the eval boards. Also added the register write workaround necessary for the PL to work.