### PR TITLE
Add host to PS DMA proof of concept driver and app

### DIFF
--- a/meta-nile/conf/dts/kula-vmk180/system-user.dtsi
+++ b/meta-nile/conf/dts/kula-vmk180/system-user.dtsi
@@ -18,7 +18,11 @@
 
 		pcie_enet_mem: buffer@70000000 {
 			no-map;
-			reg = <0x00 0x70000000 0x00 0x800000>;
+			reg = <0x00 0x70000000 0x00 0x100000>;
+		};
+		pcie_dma_mem: buffer@70100000 {
+			no-map;
+			reg = <0x00 0x70100000 0x00 0x100000>;
 		};
 	};
 
@@ -32,6 +36,18 @@
 
 		status = "okay";
 	};
+
+	hostarmdma0: dmademo {
+		compatible = "ni,host-arm-dma";
+		reg = <0x00 0x70100000 0x00 0x100000>;
+		dma-irq-gpios = <&axi_gpio_0 0 0>;
+		host-irq-out-gpios = <&axi_gpio_1>;
+
+		interrupts-extended = <&axi_gpio_0 0x0 0x1>, <&axi_gpio_1 0x0 0x1>;
+
+		status = "okay";
+	};
+
 };
 
 &cpm_pciea {

--- a/meta-nile/conf/machine/kula.conf
+++ b/meta-nile/conf/machine/kula.conf
@@ -24,7 +24,10 @@ PSM_FIRMWARE_DEPLOY_DIR = "${TMPDIR}-kula-microblaze-psm/deploy/images/${MACHINE
 CONFIG_DTFILE_DIR := "${@bb.utils.which(d.getVar('BBPATH'), 'conf/dts/${MACHINE}')}"
 CONFIG_DTFILE ?= "${CONFIG_DTFILE_DIR}/cortexa72-linux.dts"
 CONFIG_DTFILE[vardepsexclude] += "CONFIG_DTFILE_DIR"
-EXTRA_DT_INCLUDE_FILES += "${CONFIG_DTFILE_DIR}/system-user.dtsi"
+# Limit the inclusion of the system-user.dtsi overlay to only the cortexa72-linux.dts device tree since it contains
+# settings that are only valid for the Linux domain and would cause build issues if applied to the microblaze-pmc or
+# microblaze-psm device trees.
+EXTRA_DT_INCLUDE_FILES += "${@'%s/system-user.dtsi' % d.getVar('CONFIG_DTFILE_DIR') if (d.getVar('CONFIG_DTFILE') or '').endswith('cortexa72-linux.dts') else ''}"
 
 # Yocto arm-trusted-firmware(TF-A) variables
 TFA_CONSOLE ?= "pl011"

--- a/meta-nile/recipes-core/images/nile-image-dev.bb
+++ b/meta-nile/recipes-core/images/nile-image-dev.bb
@@ -16,5 +16,7 @@ IMAGE_INSTALL = "\
 IMAGE_INSTALL:append:kula = " host-arm-net-mod"
 IMAGE_INSTALL:append:kula = " libubootenv-bin"
 IMAGE_INSTALL:append:kula = " rauc"
+IMAGE_INSTALL:append:kula = " host-arm-dma-mod"
+IMAGE_INSTALL:append:kula = " host-arm-dma-user"
 
 inherit core-image

--- a/meta-nile/recipes-kernel/host-arm-dma/files/Makefile
+++ b/meta-nile/recipes-kernel/host-arm-dma/files/Makefile
@@ -1,0 +1,14 @@
+obj-m := host-arm-dma.o
+
+SRC := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c
+	rm -f Module.markers Module.symvers modules.order
+	rm -rf .tmp_versions Modules.symvers

--- a/meta-nile/recipes-kernel/host-arm-dma/files/host-arm-dma.c
+++ b/meta-nile/recipes-kernel/host-arm-dma/files/host-arm-dma.c
@@ -1,0 +1,387 @@
+/******************************************************************************
+ *
+ *   Copyright (C) 2026 National Instruments Corporation.
+ *
+ *   SPDX-License-Identifier: GPL-2.0
+ *
+ *****************************************************************************/
+
+/*
+ * This kernel module supports a proof-of-concept data path where the host DMA
+ * engine transfers data for consumption by the PS userspace demo application
+ * host-arm-dma-wait. The module receives PL interrupts when a DMA transaction
+ * is ready to process, then notifies userspace through an eventfd registered
+ * via a custom ioctl for lower-latency signaling. After processing, userspace
+ * writes back to this device node to signal to the host that processing is
+ * complete.
+ */
+
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/interrupt.h>
+#include <linux/io.h>
+#include <linux/ktime.h>
+#include <linux/fs.h>
+#include <linux/miscdevice.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/ioctl.h>
+#include <linux/eventfd.h>
+#include <linux/gpio/consumer.h>
+#include <linux/of_address.h>
+#include <linux/ioport.h>
+
+#define DRIVER_NAME "host-arm-dma"
+#define DRIVER_VERSION "0.1.0"
+
+#define HOST_ARM_DMA_IOC_MAGIC 'H'
+#define HOST_ARM_DMA_IOC_SET_EVENTFD \
+	_IOW(HOST_ARM_DMA_IOC_MAGIC, 0x01, int)
+#define HOST_ARM_DMA_IOC_CLR_EVENTFD \
+	_IO(HOST_ARM_DMA_IOC_MAGIC, 0x02)
+
+/* Matches drivers/gpio/gpio-xilinx.c register layout */
+#define XGPIO_CHANNEL1_OFFSET	0x8
+#define XGPIO_GIER_OFFSET	0x11c
+#define XGPIO_GPIER_OFFSET	0x128
+
+struct host_arm_dma_dev {
+	struct device *dev;
+	void __iomem *host_irq_out_data_reg;
+	struct gpio_desc *irq_in_gpio;
+	int irq_in;
+	bool irq_enabled;
+	atomic_long_t irq_count;
+	u64 last_isr_ns;
+	spinlock_t eventfd_lock;
+	struct eventfd_ctx *eventfd;
+	struct miscdevice miscdev;
+};
+
+static void host_arm_dma_set_irqs_enabled(struct host_arm_dma_dev *dma,
+					  bool enable)
+{
+	if (dma->irq_enabled == enable)
+		return;
+
+	if (dma->irq_in > 0) {
+		if (enable)
+			enable_irq(dma->irq_in);
+		else
+			disable_irq(dma->irq_in);
+	}
+
+	dma->irq_enabled = enable;
+}
+
+static void host_arm_dma_iounmap_action(void *data)
+{
+	iounmap(data);
+}
+
+static int host_arm_dma_init_host_irq_out(struct platform_device *pdev,
+					  struct host_arm_dma_dev *dma)
+{
+	struct device_node *host_irq_out_np;
+	struct resource res;
+	void __iomem *regs;
+	int ret;
+
+	host_irq_out_np = of_parse_phandle(pdev->dev.of_node,
+					  "host-irq-out-gpios", 0);
+	if (!host_irq_out_np) {
+		dev_err(&pdev->dev,
+			"Failed to parse host-irq-out-gpios[0]\n");
+		return -EINVAL;
+	}
+
+	ret = of_address_to_resource(host_irq_out_np, 0, &res);
+	of_node_put(host_irq_out_np);
+	if (ret) {
+		dev_err(&pdev->dev,
+			"Failed to get host-irq-out GPIO resource: %d\n", ret);
+		return ret;
+	}
+
+	regs = ioremap(res.start, resource_size(&res));
+	if (!regs) {
+		dev_err(&pdev->dev,
+			"Failed to map host-irq-out GPIO register space\n");
+		return -ENOMEM;
+	}
+
+	ret = devm_add_action_or_reset(&pdev->dev,
+					 host_arm_dma_iounmap_action,
+					 regs);
+	if (ret)
+		return ret;
+
+	dma->host_irq_out_data_reg = regs + XGPIO_CHANNEL1_OFFSET;
+
+	return 0;
+}
+
+static int host_arm_dma_open(struct inode *inode, struct file *file)
+{
+	struct miscdevice *miscdev = file->private_data;
+	struct host_arm_dma_dev *dma =
+		container_of(miscdev, struct host_arm_dma_dev, miscdev);
+
+	file->private_data = dma;
+
+	return 0;
+}
+
+static int host_arm_dma_release(struct inode *inode, struct file *file)
+{
+	file->private_data = NULL;
+	return 0;
+}
+
+static ssize_t host_arm_dma_write(struct file *file, const char __user *buf,
+				  size_t count, loff_t *ppos)
+{
+	struct host_arm_dma_dev *dma = file->private_data;
+	u32 value;
+	u64 last_isr_ns;
+	u64 write_trigger_ns;
+	u64 latency_ns;
+
+	if (!dma)
+		return -EINVAL;
+
+	if (count < sizeof(value))
+		return -EINVAL;
+
+	if (copy_from_user(&value, buf, sizeof(value)))
+		return -EFAULT;
+
+	if (!dma->host_irq_out_data_reg)
+		return -EINVAL;
+
+	writel(value, dma->host_irq_out_data_reg);
+
+	write_trigger_ns = ktime_get_ns();
+	last_isr_ns = READ_ONCE(dma->last_isr_ns);
+
+	if (last_isr_ns && write_trigger_ns >= last_isr_ns) {
+		latency_ns = write_trigger_ns - last_isr_ns;
+		dev_dbg(dma->dev,
+			 "Interrupt sent (value: %u, dma->irq_count=%ld), ISR->write latency: %llu ns\n",
+			 value, atomic_long_read(&dma->irq_count), latency_ns);
+	} else {
+		dev_dbg(dma->dev,
+			 "Interrupt sent (value: %u, dma->irq_count=%ld), ISR->write latency unavailable\n",
+			 value, atomic_long_read(&dma->irq_count));
+	}
+
+	return sizeof(value);
+}
+
+static long host_arm_dma_ioctl(struct file *file, unsigned int cmd,
+			       unsigned long arg)
+{
+	struct host_arm_dma_dev *dma = file->private_data;
+	struct eventfd_ctx *new_eventfd;
+	struct eventfd_ctx *old_eventfd;
+	unsigned long flags;
+	int eventfd_fd;
+
+	if (!dma)
+		return -EINVAL;
+
+	switch (cmd) {
+	case HOST_ARM_DMA_IOC_SET_EVENTFD:
+		if (copy_from_user(&eventfd_fd, (int __user *)arg,
+				   sizeof(eventfd_fd)))
+			return -EFAULT;
+
+		new_eventfd = eventfd_ctx_fdget(eventfd_fd);
+		if (IS_ERR(new_eventfd))
+			return PTR_ERR(new_eventfd);
+
+		spin_lock_irqsave(&dma->eventfd_lock, flags);
+		old_eventfd = dma->eventfd;
+		dma->eventfd = new_eventfd;
+		spin_unlock_irqrestore(&dma->eventfd_lock, flags);
+
+		if (old_eventfd)
+			eventfd_ctx_put(old_eventfd);
+
+		host_arm_dma_set_irqs_enabled(dma, true);
+
+		return 0;
+
+	case HOST_ARM_DMA_IOC_CLR_EVENTFD:
+		spin_lock_irqsave(&dma->eventfd_lock, flags);
+		old_eventfd = dma->eventfd;
+		dma->eventfd = NULL;
+		spin_unlock_irqrestore(&dma->eventfd_lock, flags);
+
+		if (old_eventfd)
+			eventfd_ctx_put(old_eventfd);
+
+		host_arm_dma_set_irqs_enabled(dma, false);
+
+		return 0;
+
+	default:
+		return -ENOTTY;
+	}
+}
+
+static const struct file_operations host_arm_dma_fops = {
+	.owner = THIS_MODULE,
+	.open = host_arm_dma_open,
+	.release = host_arm_dma_release,
+	.write = host_arm_dma_write,
+	.unlocked_ioctl = host_arm_dma_ioctl,
+	.llseek = default_llseek,
+};
+
+static irqreturn_t host_arm_dma_isr(int irq, void *data)
+{
+	struct host_arm_dma_dev *dma = data;
+	struct eventfd_ctx *eventfd;
+	unsigned long flags;
+
+	WRITE_ONCE(dma->last_isr_ns, ktime_get_ns());
+	atomic_long_inc(&dma->irq_count);
+
+	spin_lock_irqsave(&dma->eventfd_lock, flags);
+	eventfd = dma->eventfd;
+	if (eventfd)
+		eventfd_signal(eventfd);
+	spin_unlock_irqrestore(&dma->eventfd_lock, flags);
+
+	return IRQ_HANDLED;
+}
+
+static int host_arm_dma_probe(struct platform_device *pdev)
+{
+	struct host_arm_dma_dev *dma;
+	int ret;
+
+	dma = devm_kzalloc(&pdev->dev, sizeof(*dma), GFP_KERNEL);
+	if (!dma)
+		return -ENOMEM;
+
+	dma->dev = &pdev->dev;
+	platform_set_drvdata(pdev, dma);
+	dma->irq_enabled = false;
+	atomic_long_set(&dma->irq_count, 0);
+	spin_lock_init(&dma->eventfd_lock);
+	dma->eventfd = NULL;
+	WRITE_ONCE(dma->last_isr_ns, 0);
+
+	dma->irq_in_gpio = devm_gpiod_get_index_optional(&pdev->dev,
+								"dma-irq", 0,
+								GPIOD_IN);
+	if (IS_ERR(dma->irq_in_gpio)) {
+		dev_err(&pdev->dev, "Failed to acquire dma-irq-gpios[0] descriptor: %ld\n", PTR_ERR(dma->irq_in_gpio));
+		return PTR_ERR(dma->irq_in_gpio);
+	}
+
+	if (!dma->irq_in_gpio) {
+		dev_err(&pdev->dev, "dma-irq-gpios[0] not defined in device tree\n");
+		return -EINVAL;
+	}
+
+	dma->irq_in = gpiod_to_irq(dma->irq_in_gpio);
+	if (dma->irq_in < 0) {
+		dev_err(&pdev->dev, "Failed to get IRQ number for dma-irq-gpios[0]: %d\n", dma->irq_in);
+		return dma->irq_in;
+	}
+
+	ret = devm_request_irq(&pdev->dev, dma->irq_in, host_arm_dma_isr,
+					IRQF_NO_AUTOEN | IRQF_TRIGGER_RISING |
+					IRQF_TRIGGER_FALLING, DRIVER_NAME, dma);
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to request IRQ %d: %d\n",
+			dma->irq_in, ret);
+		return ret;
+	}
+
+	/* Drive host completion by direct write to gpio-xilinx GPIO_DATA register. */
+	ret = host_arm_dma_init_host_irq_out(pdev, dma);
+	if (ret)
+		return ret;
+
+	dma->miscdev.minor = MISC_DYNAMIC_MINOR;
+	dma->miscdev.name = devm_kasprintf(&pdev->dev, GFP_KERNEL,
+		"%s", DRIVER_NAME);
+	if (!dma->miscdev.name)
+		return -ENOMEM;
+	dma->miscdev.fops = &host_arm_dma_fops;
+	dma->miscdev.parent = &pdev->dev;
+
+	ret = misc_register(&dma->miscdev);
+	if (ret) {
+		dev_err(&pdev->dev, "Failed to register misc device: %d\n", ret);
+		return ret;
+	}
+
+	dev_info(&pdev->dev, "Eventfd control interface at /dev/%s\n", dma->miscdev.name);
+
+	return 0;
+}
+
+static void host_arm_dma_remove(struct platform_device *pdev)
+{
+	struct host_arm_dma_dev *dma = platform_get_drvdata(pdev);
+	struct eventfd_ctx *eventfd;
+	unsigned long flags;
+
+	if (!dma)
+		return;
+
+	host_arm_dma_set_irqs_enabled(dma, false);
+
+	misc_deregister(&dma->miscdev);
+
+	spin_lock_irqsave(&dma->eventfd_lock, flags);
+	eventfd = dma->eventfd;
+	dma->eventfd = NULL;
+	spin_unlock_irqrestore(&dma->eventfd_lock, flags);
+
+	if (eventfd)
+		eventfd_ctx_put(eventfd);
+
+	dev_info(dma->dev, "Unregistered DMA driver (received %ld interrupts)\n",
+		 atomic_long_read(&dma->irq_count));
+}
+
+static const struct of_device_id host_arm_dma_of_match[] = {
+	{ .compatible = "ni,host-arm-dma" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, host_arm_dma_of_match);
+
+static struct platform_driver host_arm_dma_driver = {
+	.driver = {
+		.name = DRIVER_NAME,
+		.of_match_table = host_arm_dma_of_match,
+	},
+	.probe = host_arm_dma_probe,
+	.remove = host_arm_dma_remove,
+};
+
+static int __init host_arm_dma_init(void)
+{
+	pr_info("Host ARM DMA interrupt driver v%s\n", DRIVER_VERSION);
+	return platform_driver_register(&host_arm_dma_driver);
+}
+
+static void __exit host_arm_dma_exit(void)
+{
+	platform_driver_unregister(&host_arm_dma_driver);
+}
+
+module_init(host_arm_dma_init);
+module_exit(host_arm_dma_exit);
+
+MODULE_AUTHOR("National Instruments");
+MODULE_DESCRIPTION("Host ARM DMA interrupt-driven device driver");
+MODULE_LICENSE("GPL");
+MODULE_VERSION(DRIVER_VERSION);

--- a/meta-nile/recipes-kernel/host-arm-dma/files/host-arm-dma.conf
+++ b/meta-nile/recipes-kernel/host-arm-dma/files/host-arm-dma.conf
@@ -1,0 +1,1 @@
+blacklist host-arm-dma

--- a/meta-nile/recipes-kernel/host-arm-dma/host-arm-dma-mod_0.1.bb
+++ b/meta-nile/recipes-kernel/host-arm-dma/host-arm-dma-mod_0.1.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Host ARM DMA example"
+DESCRIPTION = "${SUMMARY}"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit module
+
+SRC_URI = "file://Makefile \
+           file://host-arm-dma.c \
+           file://host-arm-dma.conf \
+          "
+
+S = "${WORKDIR}"
+
+# The inherit of module.bbclass will automatically name module packages with
+# "kernel-module-" prefix as required by the oe-core build environment.
+
+RPROVIDES:${PN} += "kernel-module-host-arm-dma"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/modprobe.d
+    install -m 0644 ${WORKDIR}/host-arm-dma.conf ${D}${sysconfdir}/modprobe.d/host-arm-dma.conf
+}
+
+FILES:${PN} += "${sysconfdir}/modprobe.d/host-arm-dma.conf"

--- a/meta-nile/recipes-user/host-arm-dma-user/files/host-arm-dma-uapi.h
+++ b/meta-nile/recipes-user/host-arm-dma-user/files/host-arm-dma-uapi.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef HOST_ARM_DMA_UAPI_H
+#define HOST_ARM_DMA_UAPI_H
+
+#include <sys/ioctl.h>
+
+#define HOST_ARM_DMA_IOC_MAGIC 'H'
+#define HOST_ARM_DMA_IOC_SET_EVENTFD \
+	_IOW(HOST_ARM_DMA_IOC_MAGIC, 0x01, int)
+#define HOST_ARM_DMA_IOC_CLR_EVENTFD \
+	_IO(HOST_ARM_DMA_IOC_MAGIC, 0x02)
+
+#endif /* HOST_ARM_DMA_UAPI_H */

--- a/meta-nile/recipes-user/host-arm-dma-user/files/host-arm-dma-wait.c
+++ b/meta-nile/recipes-user/host-arm-dma-user/files/host-arm-dma-wait.c
@@ -1,0 +1,291 @@
+/******************************************************************************
+ *
+ *   Copyright (C) 2026 National Instruments Corporation.
+ *
+ *   SPDX-License-Identifier: GPL-2.0
+ *
+ *****************************************************************************/
+
+#include <errno.h>
+#include <inttypes.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
+
+#include "host-arm-dma-uapi.h"
+
+/*
+ * High-level module note:
+ * This userspace helper supports a proof-of-concept flow where the host DMA
+ * engine places data for consumption by the demo application
+ * (host-arm-dma-wait) running in the PS userspace.
+ *
+ * The flow is:
+ * 1) The PL raises an interrupt when a DMA transaction is ready to process.
+ * 2) The kernel driver notifies userspace through an eventfd registered with
+ *    a custom ioctl, providing lower-latency signaling to this application.
+ * 3) After processing, this application writes back to the device to signal
+ *    to the host side that processing is complete.
+ */
+#define SHARED_MEM_BASE 0x70100000UL
+#define SHARED_MEM_SIZE 0x100000UL
+
+static volatile sig_atomic_t stop_requested;
+
+static void handle_stop_signal(int signo)
+{
+	(void)signo;
+	stop_requested = 1;
+}
+
+int main(int argc, char *argv[])
+{
+	const char *dev_path = "/dev/host-arm-dma";
+	int verbose = 0;
+	struct sigaction sa = { 0 };
+	int fd;
+	int efd = -1;
+	int epfd = -1;
+	int memfd = -1;
+	int ret;
+	uint8_t *shared_mem = MAP_FAILED;
+
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
+			verbose = 1;
+		} else {
+			fprintf(stderr, "Unknown argument: %s\n", argv[i]);
+			fprintf(stderr, "Usage: %s [-v|--verbose]\n", argv[0]);
+			return EXIT_FAILURE;
+		}
+	}
+
+	sa.sa_handler = handle_stop_signal;
+	sigemptyset(&sa.sa_mask);
+	if (sigaction(SIGINT, &sa, NULL) < 0 || sigaction(SIGTERM, &sa, NULL) < 0) {
+		fprintf(stderr, "Failed to install signal handlers: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	fd = open(dev_path, O_RDWR);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s: %s\n", dev_path, strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/*
+	 * Use semaphore mode so each read consumes one signal instead of draining
+	 * the full counter value, which preserves pending wakeups across loops.
+	 */
+	efd = eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE);
+	if (efd < 0) {
+		fprintf(stderr, "Failed to create eventfd: %s\n", strerror(errno));
+		close(fd);
+		return EXIT_FAILURE;
+	}
+
+	memfd = open("/dev/mem", O_RDONLY | O_SYNC);
+	if (memfd < 0) {
+		fprintf(stderr, "Failed to open /dev/mem: %s\n", strerror(errno));
+		close(efd);
+		close(fd);
+		return EXIT_FAILURE;
+	}
+
+	shared_mem = mmap(NULL, SHARED_MEM_SIZE, PROT_READ, MAP_SHARED, memfd,
+			  SHARED_MEM_BASE);
+	if (shared_mem == MAP_FAILED) {
+		fprintf(stderr,
+			"Failed to map shared memory at 0x%lx (size 0x%lx): %s\n",
+			(unsigned long)SHARED_MEM_BASE,
+			(unsigned long)SHARED_MEM_SIZE,
+			strerror(errno));
+		close(memfd);
+		close(efd);
+		close(fd);
+		return EXIT_FAILURE;
+	}
+
+	ret = ioctl(fd, HOST_ARM_DMA_IOC_SET_EVENTFD, &efd);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to register eventfd with driver: %s\n",
+			strerror(errno));
+		munmap(shared_mem, SHARED_MEM_SIZE);
+		close(memfd);
+		close(efd);
+		close(fd);
+		return EXIT_FAILURE;
+	}
+
+	epfd = epoll_create1(EPOLL_CLOEXEC);
+	if (epfd < 0) {
+		fprintf(stderr, "Failed to create epoll fd: %s\n", strerror(errno));
+		(void)ioctl(fd, HOST_ARM_DMA_IOC_CLR_EVENTFD);
+		munmap(shared_mem, SHARED_MEM_SIZE);
+		close(memfd);
+		close(efd);
+		close(fd);
+		return EXIT_FAILURE;
+	}
+
+	{
+		struct epoll_event ev = { 0 };
+
+		ev.events = EPOLLIN;
+		ev.data.fd = efd;
+		if (epoll_ctl(epfd, EPOLL_CTL_ADD, efd, &ev) < 0) {
+			fprintf(stderr, "Failed to add eventfd to epoll: %s\n",
+				strerror(errno));
+			close(epfd);
+			(void)ioctl(fd, HOST_ARM_DMA_IOC_CLR_EVENTFD);
+			munmap(shared_mem, SHARED_MEM_SIZE);
+			close(memfd);
+			close(efd);
+			close(fd);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (verbose) {
+		printf("Waiting for interrupts on %s via epoll/eventfd (Ctrl-C to exit)\n",
+		       dev_path);
+	}
+
+	uint64_t irq_count = 0;
+	while (!stop_requested) {
+		struct epoll_event ev;
+		uint64_t signaled = 0;
+		int nready = epoll_wait(epfd, &ev, 1, -1);
+
+		if (nready < 0 && errno == EINTR)
+			continue;
+		if (nready < 0) {
+			printf("epoll_wait failed: %s\n", strerror(errno));
+			break;
+		}
+		if (nready == 0) {
+			continue;
+		}
+
+		if (ev.data.fd == efd && (ev.events & EPOLLIN)) {
+			++irq_count;
+			uint8_t *shared_mem_snapshot = NULL;
+			uint32_t shared_mem_read_bytes = 0;
+			struct timespec memcpy_start;
+			struct timespec memcpy_end;
+			double memcpy_us = -1.0;
+
+			if (SHARED_MEM_SIZE < sizeof(shared_mem_read_bytes)) {
+				printf("Shared memory size too small to read length field\n");
+				break;
+			}
+
+			/* Read length field as volatile uint32_t to ensure proper access */
+			volatile uint32_t *len_ptr = (volatile uint32_t *)shared_mem;
+			shared_mem_read_bytes = *len_ptr;
+
+			if (shared_mem_read_bytes > (SHARED_MEM_SIZE - sizeof(shared_mem_read_bytes))) {
+				printf("Invalid shared memory length %" PRIu32
+				       " (max payload %lu)\n",
+				       shared_mem_read_bytes,
+				       (unsigned long)(SHARED_MEM_SIZE - sizeof(shared_mem_read_bytes)));
+				break;
+			}
+
+			if (shared_mem_read_bytes > 0) {
+				shared_mem_snapshot = malloc(shared_mem_read_bytes);
+				if (!shared_mem_snapshot) {
+					printf("Failed to allocate %" PRIu32 " bytes for shared memory snapshot\n",
+					       shared_mem_read_bytes);
+					break;
+				}
+			}
+
+			clock_gettime(CLOCK_MONOTONIC, &memcpy_start);
+			if (shared_mem_read_bytes > 0) {
+				/* Read payload in 4-byte aligned chunks using volatile access */
+				volatile uint32_t *src = (volatile uint32_t *)(shared_mem + sizeof(shared_mem_read_bytes));
+				uint32_t *dst = (uint32_t *)shared_mem_snapshot;
+				uint32_t remaining = shared_mem_read_bytes;
+
+				/* Copy 4-byte aligned chunks */
+				while (remaining >= sizeof(uint32_t)) {
+					*dst++ = *src++;
+					remaining -= sizeof(uint32_t);
+				}
+
+				/* Copy any remaining bytes (< 4) */
+				if (remaining > 0) {
+					uint8_t *src_bytes = (uint8_t *)src;
+					uint8_t *dst_bytes = (uint8_t *)dst;
+					for (uint32_t i = 0; i < remaining; i++) {
+						dst_bytes[i] = src_bytes[i];
+					}
+				}
+			}
+			clock_gettime(CLOCK_MONOTONIC, &memcpy_end);
+			memcpy_us =
+				((double)(memcpy_end.tv_sec - memcpy_start.tv_sec) * 1000000.0) +
+				((double)(memcpy_end.tv_nsec - memcpy_start.tv_nsec) / 1000.0);
+
+			uint32_t trigger_value = (uint32_t)irq_count;
+			ssize_t wn = write(fd, &trigger_value, sizeof(trigger_value));
+			if (wn != (ssize_t)sizeof(trigger_value)) {
+				if (wn < 0)
+					printf("Trigger write failed: %s\n", strerror(errno));
+				else
+					printf("Trigger short write: got %zd bytes, expected %zu\n",
+						wn, sizeof(trigger_value));
+				free(shared_mem_snapshot);
+				break;
+			}
+
+			ssize_t rn = read(efd, &signaled, sizeof(signaled));
+			if (rn != (ssize_t)sizeof(signaled)) {
+				if (rn < 0)
+					printf("eventfd read failed: %s\n", strerror(errno));
+				else
+					printf("eventfd short read: got %zd bytes, expected %zu\n",
+						rn, sizeof(signaled));
+				free(shared_mem_snapshot);
+				break;
+			}
+
+			if (verbose) {
+				printf("Interrupt received, count=%" PRIu64 " (batch=%" PRIu64 ")\n",
+				       irq_count, signaled);
+				printf("Shared memory [0x%lx] payload (%" PRIu32 " bytes):",
+				       (unsigned long)SHARED_MEM_BASE,
+				       shared_mem_read_bytes);
+				printf("\n");
+				printf("memcpy time: %.3f us\n", memcpy_us);
+			}
+			free(shared_mem_snapshot);
+
+			fflush(stdout);
+			continue;
+		}
+
+		fprintf(stderr, "Unexpected epoll event: 0x%x\n", ev.events);
+		break;
+	}
+
+	(void)ioctl(fd, HOST_ARM_DMA_IOC_CLR_EVENTFD);
+	munmap(shared_mem, SHARED_MEM_SIZE);
+	close(memfd);
+	close(epfd);
+	close(efd);
+	close(fd);
+	printf("Exiting.\n");
+
+	return EXIT_SUCCESS;
+}

--- a/meta-nile/recipes-user/host-arm-dma-user/host-arm-dma-user_0.1.bb
+++ b/meta-nile/recipes-user/host-arm-dma-user/host-arm-dma-user_0.1.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Userspace waiter for host-arm-dma interrupts"
+DESCRIPTION = "Simple userspace app that blocks waiting on /dev/host-arm-dma events"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+SRC_URI = "file://host-arm-dma-wait.c \
+		   file://host-arm-dma-uapi.h"
+
+S = "${WORKDIR}"
+
+do_compile() {
+	${CC} ${CFLAGS} ${CPPFLAGS} ${LDFLAGS} host-arm-dma-wait.c -o host-arm-dma-wait
+}
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 0755 host-arm-dma-wait ${D}${bindir}/host-arm-dma-wait
+}


### PR DESCRIPTION
Add our proof of concept demonstration sending packets of information to a waiting PS user application from the host via QDMA over PCIe. A kernel module handles interrupts to and from the PL and notifies the user appliction for new transactions.

A user mode application waits on events, reads data out, then notifies the kernel the transaction is complete.