### PR TITLE
Add the PCIe net driver to the loading blacklist

### DIFF
--- a/meta-nile/recipes-kernel/host-arm-net/files/host-arm-net.conf
+++ b/meta-nile/recipes-kernel/host-arm-net/files/host-arm-net.conf
@@ -1,0 +1,1 @@
+blacklist host-arm-net

--- a/meta-nile/recipes-kernel/host-arm-net/host-arm-net-mod_0.1.bb
+++ b/meta-nile/recipes-kernel/host-arm-net/host-arm-net-mod_0.1.bb
@@ -7,6 +7,7 @@ inherit module
 
 SRC_URI = "file://Makefile \
            file://host-arm-net.c \
+           file://host-arm-net.conf \
           "
 
 S = "${WORKDIR}"
@@ -15,3 +16,10 @@ S = "${WORKDIR}"
 # "kernel-module-" prefix as required by the oe-core build environment.
 
 RPROVIDES:${PN} += "kernel-module-host-arm-net"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/modprobe.d
+    install -m 0644 ${WORKDIR}/host-arm-net.conf ${D}${sysconfdir}/modprobe.d/host-arm-net.conf
+}
+
+FILES:${PN} += "${sysconfdir}/modprobe.d/host-arm-net.conf"


### PR DESCRIPTION
Prevent the PCIe net driver from loading on boot to more conveniently select when to load it in dev testing using modprobe.