### PR TITLE
Add a defined "self-test" entrypoint

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -168,6 +168,11 @@ target:
   - xyzzy-firmware
 ```
 
+### Self Test
+
+Client teams should implement a self test for their products. See
+[self-test.md](self-test.md).
+
 ## Build Pipeline
 
 _TODO. Since this is largely internal-focused should this link to a document

--- a/docs/self-test.md
+++ b/docs/self-test.md
@@ -1,0 +1,42 @@
+# Image Self-Test
+
+It is generally expected that most NILE-based products will have some
+service or set of services to provide product-specific functionality.
+NILE maintainers are interested in being able to assess that changes to
+shared infrastructure do not break that product-specific behavior, but
+we need a common way to determine if product-specific behavior is okay.
+
+Therefore, NILE presents a self-test hook for clients to implement.
+
+## Implementing the Self-Test
+
+Clients are expected to have a `nile-selftest.bbappend` that installs a
+script or executable of their choosing as `/usr/bin/nile-selftest`.
+
+`nile-selftest` is currently run through a ptest runner, and as such, any
+output it has should follow [ptest output format](https://docs.yoctoproject.org/scarthgap/test-manual/ptest.html#testing-packages-with-ptest).
+The ptest runner also checks the exit code of `nile-selftest` and reports
+a failure on non-zero return.
+
+See [the meta-nile-test implementation](/meta-nile-test/recipes-test/nile-selftest)
+for an example.
+
+Note that failure to implement a self-test is not treated as a build
+failure, but it will be considered a self-test failure.
+
+nile-selftest is implemented with a recipe that clients can .bbappend if
+they need custom rules (such as to compile an executable), but it is
+recommended that you NOT have an RDEPEND in nile-selftest.bbappend on any
+packages that you expect to be in your image, so as to avoid the
+nile-selftest package from becoming load-bearing.
+
+## What should Self-Test cover?
+
+The self-test should be generally pretty simple, and operate "quickly".
+Things that would be appropriate for a self-test:
+- ensure that particular drivers have loaded
+- check to see if a service or set of services are running
+- perform a "ping" against a local service to ensure it's responding
+
+More rigorous testing should be handled in product-specific test suites,
+and not the self-test.

--- a/meta-nile-test/recipes-test/nile-selftest/files/nile-selftest
+++ b/meta-nile-test/recipes-test/nile-selftest/files/nile-selftest
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This should probably be a more rigorous check but this test target
+# is intended to be rather lightweight, so there's not much in the way
+# of hardware capability that we can really check for.
+if [ ! -f /sys/class/fpga_manager/fpga0/name ]; then
+	echo "FAIL: no fpga device found"
+	exit 1
+else
+	echo "PASS: fpga device is present"
+	exit 0
+fi

--- a/meta-nile-test/recipes-test/nile-selftest/nile-selftest.bbappend
+++ b/meta-nile-test/recipes-test/nile-selftest/nile-selftest.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://nile-selftest"
+
+S = "${WORKDIR}"
+
+do_install:append () {
+	install -d ${D}${bindir}
+	install -m 0755 ${S}/nile-selftest ${D}${bindir}
+}

--- a/meta-nile/recipes-core/packagegroups/packagegroup-nile-ptests-core.bb
+++ b/meta-nile/recipes-core/packagegroups/packagegroup-nile-ptests-core.bb
@@ -15,4 +15,5 @@ RDEPENDS:${PN} += "ptest-runner "
 
 RDEPENDS:${PN} += "\
     xz-ptest \
+    nile-selftest-ptest \
     "

--- a/meta-nile/recipes-test/nile-selftest/files/nile-selftest-qemu
+++ b/meta-nile/recipes-test/nile-selftest/files/nile-selftest-qemu
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -f /sys/firmware/devicetree/base/model ]; then
+	read MODEL < /sys/firmware/devicetree/base/model
+	echo "model is ${MODEL}, wanting linux,dummy-virt"
+	if [ "${MODEL}" = "linux,dummy-virt" ]; then
+		echo "PASS: model-check"
+		exit 0
+	else
+		echo "FAIL: model-check"
+		exit 1
+	fi
+else
+	# TODO (AB#3968257): for non-devicetree QEMU platforms (e.g. x64) we should look at /sys/class/dmi/id
+	echo "model check not implemented on non-devicetree platforms :("
+	echo "FAIL: model-check"
+	exit 1
+fi

--- a/meta-nile/recipes-test/nile-selftest/files/run-ptest
+++ b/meta-nile/recipes-test/nile-selftest/files/run-ptest
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# ptest wrapper to run nile-selftest as part of ptest runs
+
+if [ ! -f /usr/bin/nile-selftest ]; then
+	echo "nile-selftest not present, cannot run"
+	echo "FAIL: nile-selftest"
+	exit 1
+fi
+
+/usr/bin/nile-selftest
+RET=$?
+
+if [ $RET -eq 0 ]; then
+	echo "PASS: nile-selftest"
+	exit 0
+else
+	echo "nile-selftest returned non-zero exit code ${RET}"
+	echo "FAIL: nile-selftest"
+	exit $RET
+fi

--- a/meta-nile/recipes-test/nile-selftest/nile-selftest.bb
+++ b/meta-nile/recipes-test/nile-selftest/nile-selftest.bb
@@ -1,0 +1,45 @@
+# nile-selftest is a generic entrypoint
+# Every device in NILE should expose a machine-specific "nile-selftest"
+# script that performs some sort of simple "hardware is working"
+# verification, and install it to ${bindir}/nile-selftest.
+#
+# meta-nile then contains the infrastructure to run that as a ptest.
+#
+# Devices are permitted to add other ptests, and are encouraged to do so.
+# However, abstracting out a self-test in this manner lets us do two things:
+#
+# - /usr/bin/nile-selftest becomes a known entrypoint that can function
+#   without ptests, should we choose to use a different test executor in the
+#   future
+# - having this have a known, consistent name across all devices lets the
+#   NILE team more accurately assess platform health without needing to know
+#   details about the inner workings of individual products.
+
+SUMMARY = "NILE Self Test"
+DESCRIPTION = "Target-specific self-test"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+inherit ptest
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://run-ptest"
+
+S = "${WORKDIR}"
+
+# nile-selftest will be an empty package if no client layer has a .bbappend
+# to install a nile-selftest executable. (The ptest runner handles this
+# condition as a failure.)
+ALLOW_EMPTY:${PN} = "1"
+
+# This recipe handles the qemu* targets directly, as those are expected to
+# be handled completely with meta-nile (e.g. no target-specific client layer).
+# Client layers should have their own .bbappend to install their own 'nile-selftest'.
+SRC_URI:append:qemuall = " file://nile-selftest-qemu"
+
+do_install:append:qemuall () {
+        install -d ${D}${bindir}
+        install -m 0755 ${S}/nile-selftest-qemu ${D}${bindir}/nile-selftest
+}


### PR DESCRIPTION
Creates a new package, `nile-selftest`, and documents its usage.

This is intended as a generic hook for clients to implement, so that at an infrastructure level we have a common approach to sanity-check an image without necessarily knowing product-level details.

This is currently implemented with the ptest runner; however, it being run this way is a detail generally abstracted from clients, and we might choose to run self-tests in a non-ptest stage in the future. (However, we do specify that if clients do output then it must be in a ptest-compatible format.)

Implements [AB#3762710](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3762710).